### PR TITLE
Use native alias instead of stock function

### DIFF
--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -85,8 +85,7 @@ native DCC_Role:DCC_FindRoleById(const role_id[]);
 native DCC_GetRoleId(DCC_Role:role, dest[DCC_ID_SIZE], max_size = sizeof dest);
 native DCC_GetRoleName(DCC_Role:role, dest[], max_size = sizeof dest);
 native DCC_GetRoleColor(DCC_Role:role, &color);
-stock DCC_GetRoleColour(DCC_Role:role, &colour) // for our British mates
-	return DCC_GetRoleColor(role, colour);
+native DCC_GetRoleColour(DCC_Role:role, &colour) = DCC_GetRoleColor; // for our British mates
 native DCC_GetRolePermissions(DCC_Role:role, &perm_high, &perm_low); // 64 bit integer
 native DCC_IsRoleHoist(DCC_Role:role, &bool:is_hoist);
 native DCC_IsRoleMentionable(DCC_Role:role, &bool:is_mentionable);


### PR DESCRIPTION
Reduces overhead

I'd remove the entire function though...