### PR TITLE
read discord token from environment variable

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,6 +61,17 @@ bool WaitForInitialization()
 	return false;
 }
 
+std::string GetEnviron(std::string key) {
+	#ifdef WIN32
+	char* buffer[128];
+	result = GetEnvironmentVariableA(key.c_str(), buffer, length);
+	#else
+	const char* buffer = getenv(key);
+	#endif
+	return std::string(buffer);
+
+}
+
 PLUGIN_EXPORT unsigned int PLUGIN_CALL Supports()
 {
 	return SUPPORTS_VERSION | SUPPORTS_AMX_NATIVES | SUPPORTS_PROCESS_TICK;
@@ -72,8 +83,13 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 	logprintf = (logprintf_t) ppData[PLUGIN_DATA_LOGPRINTF];
 	
 	bool ret_val = true;
-	std::string bot_token;
-	if (SampConfigReader::Get()->GetVar("discord_bot_token", bot_token))
+	std::string bot_token = GetEnviron("DISCORD_BOT_TOKEN");
+
+	if(bot_token.empty()) {
+		SampConfigReader::Get()->GetVar("discord_bot_token", bot_token);
+	}
+
+	if (!bot_token.empty())
 	{
 		InitializeEverything(bot_token);
 
@@ -104,7 +120,7 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 	}
 	else
 	{
-		logprintf(" >> plugin.dc-connector: bot token not specified in server config.");
+		logprintf(" >> plugin.dc-connector: bot token not specified in environment variable or server config.");
 		ret_val = false;
 	}
 	return ret_val;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,15 +61,16 @@ bool WaitForInitialization()
 	return false;
 }
 
-std::string GetEnviron(std::string key) {
+std::string GetEnviron(std::string key)
+{
 	#ifdef WIN32
 	char* buffer[128];
 	result = GetEnvironmentVariableA(key.c_str(), buffer, length);
 	#else
 	const char* buffer = getenv(key);
 	#endif
-	return std::string(buffer);
 
+	return std::string(buffer);
 }
 
 PLUGIN_EXPORT unsigned int PLUGIN_CALL Supports()
@@ -85,7 +86,8 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 	bool ret_val = true;
 	std::string bot_token = GetEnviron("DISCORD_BOT_TOKEN");
 
-	if(bot_token.empty()) {
+	if(bot_token.empty())
+	{
 		SampConfigReader::Get()->GetVar("discord_bot_token", bot_token);
 	}
 


### PR DESCRIPTION
Attempts to read the token from the environment variable `DISCORD_BOT_TOKEN` (same as the cfg key but uppercase), falls back to server.cfg if not present.

This change is to encourage the storage of sensitive credentials and passing to processes via environment variables which is a much safer approach than persisting into a file on-disk. This is part of the "12 Factor App": https://12factor.net/config