### PR TITLE
Update pawn.json to include additional SSL DLLs

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -19,7 +19,9 @@
             "includes": ["discord-connector-.+\\/pawno\\/include"],
             "plugins": ["discord-connector-.+\\/plugins\\/discord-connector\\.dll"],
             "files": {
-                "discord-connector-.+\\/log-core2.dll": "log-core2.dll"
+                "discord-connector-.+\\/log-core2.dll": "log-core2.dll",
+                "discord-connector-.+\\/libcrypto-1_1.dll": "libcrypto-1_1.dll",
+                "discord-connector-.+\\/libssl-1_1.dll": "libssl-1_1.dll"
             }
         }
     ],


### PR DESCRIPTION
https://discordapp.com/channels/231799104731217931/231799180127895553/579406156968099870

😀 

On a related note I think it might be a good idea to have a more descriptive error message if there's a problem with these files, akin to what is shown when the bot token is not set, for example.