### PR TITLE
Persistent message support, Reaction support & ability to now edit messages.

### DIFF
--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -89,13 +89,14 @@ native DCC_DeleteMessage(DCC_Message:message);
 
 native DCC_Message:DCC_GetCreatedMessage(); // for use in DCC_SendChannelMessage result callback
 
+native DCC_DeleteInternalMessage(DCC_Message:message); // This deletes a stored message, this DOES NOT delete it on discord, this is for persistent messages.
 
 //  users
 native DCC_User:DCC_FindUserByName(const user_name[], const user_discriminator[]);
 native DCC_User:DCC_FindUserById(const user_id[]);
 
-native DCC_GetUserId(DCC_User:user, dest[DCC_ID_SIZE], max_size = DCC_ID_SIZE);
 native DCC_GetUserName(DCC_User:user, dest[DCC_USERNAME_SIZE], max_size = sizeof dest);
+native DCC_GetUserId(DCC_User:user, dest[DCC_ID_SIZE], max_size = DCC_ID_SIZE);
 native DCC_GetUserDiscriminator(DCC_User:user, dest[], max_size = sizeof dest);
 native DCC_IsUserBot(DCC_User:user, &bool:is_bot);
 native DCC_IsUserVerified(DCC_User:user, &bool:is_verified);

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -39,6 +39,13 @@ enum DCC_BotPresenceStatus
 	OFFLINE
 };
 
+enum DCC_MessageReactionType
+{
+	REACTION_ADD = 0, // Sent when a user adds a reaction to a message.
+	REACTION_REMOVE, // Sent when a user removes a reaction from a message.
+	REACTION_REMOVE_ALL, // Sent when a user explicitly removes all reactions from a message.
+	REACTION_REMOVE_EMOJI // Sent when a bot removes all instances of a given emoji from the reactions of a message.
+};
 
 #define DCC_INVALID_CHANNEL DCC_Channel:0
 #define DCC_INVALID_USER DCC_User:0
@@ -213,7 +220,7 @@ forward DCC_OnChannelDelete(DCC_Channel:channel);
 // messages
 forward DCC_OnMessageCreate(DCC_Message:message);
 forward DCC_OnMessageDelete(DCC_Message:message);
-forward DCC_OnMessageReactionAdd(DCC_Message:message, DCC_User:reaction_user, DCC_Emoji:emoji);
+forward DCC_OnMessageReaction(DCC_Message:message, DCC_User:reaction_user, DCC_Emoji:emoji, DCC_MessageReactionType:reaction_type);
 
 //  users
 forward DCC_OnUserUpdate(DCC_User:user);

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -210,7 +210,7 @@ native DCC_GetEmojiName(DCC_Emoji:emoji, dest[DCC_EMOJI_NAME_SIZE], maxlen = DCC
 
 // reaction
 native DCC_CreateReaction(DCC_Message:message, DCC_Emoji:reaction_emoji);
-native DCC_DeleteMessageReaction(DCC_Message:message, DCC_Emoji:reaction_emoji = 0); // if reaction_emoji is 0 (default value) this will delete ALL of the reactions on the message.
+native DCC_DeleteMessageReaction(DCC_Message:message, DCC_Emoji:reaction_emoji = DCC_Emoji:0); // if reaction_emoji is 0 (default value) this will delete ALL of the reactions on the message.
 
 // callbacks
 //  channels

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -99,6 +99,8 @@ native DCC_DeleteInternalMessage(DCC_Message:message); // This deletes a stored 
 
 native DCC_EditMessage(DCC_Message:message, const content[], DCC_Embed:embed = DCC_Embed:0);
 
+native DCC_SetMessagePersistent(DCC_Message:message, bool:persistent);
+native DCC_CacheChannelMessage(const channel_id[DCC_ID_SIZE], const message_id[DCC_ID_SIZE], const callback[] = "", const format[] = "", {Float, _}:...);
 //  users
 native DCC_User:DCC_FindUserByName(const user_name[], const user_discriminator[]);
 native DCC_User:DCC_FindUserById(const user_id[]);

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -210,6 +210,7 @@ native DCC_GetEmojiName(DCC_Emoji:emoji, dest[DCC_EMOJI_NAME_SIZE], maxlen = DCC
 
 // reaction
 native DCC_CreateReaction(DCC_Message:message, DCC_Emoji:reaction_emoji);
+native DCC_DeleteMessageReaction(DCC_Message:message, DCC_Emoji:reaction_emoji = 0); // if reaction_emoji is 0 (default value) this will delete ALL of the reactions on the message.
 
 // callbacks
 //  channels

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -91,6 +91,8 @@ native DCC_Message:DCC_GetCreatedMessage(); // for use in DCC_SendChannelMessage
 
 native DCC_DeleteInternalMessage(DCC_Message:message); // This deletes a stored message, this DOES NOT delete it on discord, this is for persistent messages.
 
+native DCC_EditMessage(DCC_Message:message, const content[], DCC_Embed:embed = DCC_Embed:0);
+
 //  users
 native DCC_User:DCC_FindUserByName(const user_name[], const user_discriminator[]);
 native DCC_User:DCC_FindUserById(const user_id[]);
@@ -156,7 +158,6 @@ native DCC_SetGuildRoleMentionable(DCC_Guild:guild, DCC_Role:role, bool:mentiona
 native DCC_CreateGuildRole(DCC_Guild:guild, const name[], const callback[] = "", const format[] = "", {Float, _}:...);
 native DCC_Role:DCC_GetCreatedGuildRole();
 native DCC_DeleteGuildRole(DCC_Guild:guild, DCC_Role:role);
-
 
 // bot
 native DCC_BotPresenceStatus:DCC_GetBotPresenceStatus();

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -56,7 +56,6 @@ enum DCC_MessageReactionType
 #define DCC_USERNAME_SIZE (32 + 1)
 #define DCC_NICKNAME_SIZE (32 + 1)
 #define DCC_EMOJI_NAME_SIZE (32 + 1)
-#define DCC_SNOWFLAKE_SIZE (64 + 1)
 // natives
 //  channels
 native DCC_Channel:DCC_FindChannelByName(const channel_name[]);
@@ -204,7 +203,7 @@ native DCC_SetEmbedThumbnail(DCC_Embed:embed, const thumbnail_url[]);
 native DCC_SetEmbedImage(DCC_Embed:embed, const image_url[]);
 
 // emoji
-native DCC_Emoji:DCC_CreateEmoji(const name[DCC_EMOJI_NAME_SIZE], const snowflake[DCC_SNOWFLAKE_SIZE] = "");
+native DCC_Emoji:DCC_CreateEmoji(const name[DCC_EMOJI_NAME_SIZE], const snowflake[DCC_ID_SIZE] = "");
 native DCC_DeleteEmoji(DCC_Emoji:emoji);
 native DCC_GetEmojiName(DCC_Emoji:emoji, dest[DCC_EMOJI_NAME_SIZE], maxlen = DCC_EMOJI_NAME_SIZE);
 

--- a/discord-connector.inc.in
+++ b/discord-connector.inc.in
@@ -48,8 +48,8 @@ enum DCC_BotPresenceStatus
 #define DCC_ID_SIZE (20 + 1)
 #define DCC_USERNAME_SIZE (32 + 1)
 #define DCC_NICKNAME_SIZE (32 + 1)
-
-
+#define DCC_EMOJI_NAME_SIZE (32 + 1)
+#define DCC_SNOWFLAKE_SIZE (64 + 1)
 // natives
 //  channels
 native DCC_Channel:DCC_FindChannelByName(const channel_name[]);
@@ -195,6 +195,14 @@ native DCC_SetEmbedFooter(DCC_Embed:embed, const footer_text[], const footer_ico
 native DCC_SetEmbedThumbnail(DCC_Embed:embed, const thumbnail_url[]);
 native DCC_SetEmbedImage(DCC_Embed:embed, const image_url[]);
 
+// emoji
+native DCC_Emoji:DCC_CreateEmoji(const name[DCC_EMOJI_NAME_SIZE], const snowflake[DCC_SNOWFLAKE_SIZE] = "");
+native DCC_DeleteEmoji(DCC_Emoji:emoji);
+native DCC_GetEmojiName(DCC_Emoji:emoji, dest[DCC_EMOJI_NAME_SIZE], maxlen = DCC_EMOJI_NAME_SIZE);
+
+// reaction
+native DCC_CreateReaction(DCC_Message:message, DCC_Emoji:reaction_emoji);
+
 // callbacks
 //  channels
 forward DCC_OnChannelCreate(DCC_Channel:channel);
@@ -204,6 +212,7 @@ forward DCC_OnChannelDelete(DCC_Channel:channel);
 // messages
 forward DCC_OnMessageCreate(DCC_Message:message);
 forward DCC_OnMessageDelete(DCC_Message:message);
+forward DCC_OnMessageReactionAdd(DCC_Message:message, DCC_User:reaction_user, DCC_Emoji:emoji);
 
 //  users
 forward DCC_OnUserUpdate(DCC_User:user);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,8 @@ add_samp_plugin(discord-connector
 	WebSocket.hpp
 	Embed.cpp
 	Embed.hpp
+	Emoji.cpp
+	Emoji.hpp
 	main.cpp
 	misc.hpp
 	natives.cpp

--- a/src/Callback.hpp
+++ b/src/Callback.hpp
@@ -9,7 +9,6 @@
 #include <vector>
 #include <cstring>
 
-
 namespace pawn_cb
 {
 	namespace _internal
@@ -297,13 +296,17 @@ namespace pawn_cb
 
 			if (amx_address >= 0)
 				amx_Release(_amx, amx_address);
-
 			return error == AMX_ERR_NONE;
 		}
 		bool Execute()
 		{
-			cell unused;
-			return Execute(unused);
+			cell return_value;
+			bool error = !Execute(return_value);
+			if (error)
+			{
+				return false;
+			}
+			return static_cast<bool>(return_value);
 		}
 
 	private:

--- a/src/Callback.hpp
+++ b/src/Callback.hpp
@@ -300,13 +300,8 @@ namespace pawn_cb
 		}
 		bool Execute()
 		{
-			cell return_value;
-			bool error = !Execute(return_value);
-			if (error)
-			{
-				return false;
-			}
-			return static_cast<bool>(return_value);
+			cell unused;
+			return Execute(unused);
 		}
 
 	private:

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -98,11 +98,9 @@ void Channel::SendMessage(std::string &&msg, pawn_cb::Callback_t &&cb)
 					if (msg != INVALID_MESSAGE_ID)
 					{
 						MessageManager::Get()->SetCreatedMessageId(msg);
-						cell ret_val;
-						cb->Execute(ret_val);
-						if (!ret_val)
+						cb->Execute();
+						if (!MessageManager::Get()->Find(msg)->Persistent())
 						{
-							// Callback returned false, delete our stored message.
 							MessageManager::Get()->Delete(msg);
 						}
 						MessageManager::Get()->SetCreatedMessageId(INVALID_MESSAGE_ID);
@@ -248,9 +246,8 @@ void Channel::SendEmbeddedMessage(const Embed_t & embed, std::string&& msg, pawn
 						if (msg != INVALID_MESSAGE_ID)
 						{
 							MessageManager::Get()->SetCreatedMessageId(msg);
-							cell ret_val;
-							cb->Execute(ret_val);
-							if (!ret_val)
+							cb->Execute();
+							if (!MessageManager::Get()->Find(msg)->Persistent())
 							{
 								MessageManager::Get()->Delete(msg);
 							}

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -98,7 +98,9 @@ void Channel::SendMessage(std::string &&msg, pawn_cb::Callback_t &&cb)
 					if (msg != INVALID_MESSAGE_ID)
 					{
 						MessageManager::Get()->SetCreatedMessageId(msg);
-						if (!cb->Execute())
+						cell ret_val;
+						cb->Execute(ret_val);
+						if (!ret_val)
 						{
 							// Callback returned false, delete our stored message.
 							MessageManager::Get()->Delete(msg);
@@ -246,7 +248,9 @@ void Channel::SendEmbeddedMessage(const Embed_t & embed, std::string&& msg, pawn
 						if (msg != INVALID_MESSAGE_ID)
 						{
 							MessageManager::Get()->SetCreatedMessageId(msg);
-							if (!cb->Execute())
+							cell ret_val;
+							cb->Execute(ret_val);
+							if (!ret_val)
 							{
 								MessageManager::Get()->Delete(msg);
 							}

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -98,10 +98,12 @@ void Channel::SendMessage(std::string &&msg, pawn_cb::Callback_t &&cb)
 					if (msg != INVALID_MESSAGE_ID)
 					{
 						MessageManager::Get()->SetCreatedMessageId(msg);
-						cb->Execute();
+						if (!cb->Execute())
+						{
+							// Callback returned false, delete our stored message.
+							MessageManager::Get()->Delete(msg);
+						}
 						MessageManager::Get()->SetCreatedMessageId(INVALID_MESSAGE_ID);
-
-						MessageManager::Get()->Delete(msg);
 					}
 				});
 			}
@@ -244,10 +246,11 @@ void Channel::SendEmbeddedMessage(const Embed_t & embed, std::string&& msg, pawn
 						if (msg != INVALID_MESSAGE_ID)
 						{
 							MessageManager::Get()->SetCreatedMessageId(msg);
-							cb->Execute();
+							if (!cb->Execute())
+							{
+								MessageManager::Get()->Delete(msg);
+							}
 							MessageManager::Get()->SetCreatedMessageId(INVALID_MESSAGE_ID);
-
-							MessageManager::Get()->Delete(msg);
 						}
 					});
 			}

--- a/src/Emoji.cpp
+++ b/src/Emoji.cpp
@@ -1,0 +1,52 @@
+#include "Emoji.hpp"
+#include "Network.hpp"
+#include "PawnDispatcher.hpp"
+#include "Callback.hpp"
+#include "Logger.hpp"
+#include "utils.hpp"
+
+
+Emoji::Emoji(Snowflake_t const& id, std::string const& name) :
+	_id(id),
+	_name(name)
+{
+}
+
+EmojiId_t EmojiManager::AddEmoji(Snowflake_t const & snowflake, std::string const & name)
+{
+	EmojiId_t id = 1;
+	while (m_Emojis.find(id) != m_Emojis.end())
+		++id;
+
+	if (!m_Emojis.emplace(id, Emoji_t(new Emoji(snowflake, name))).first->second)
+	{
+		Logger::Get()->Log(LogLevel::ERROR,
+			"can't create embed: duplicate key '{}'", id);
+		return INVALID_USER_ID;
+	}
+
+	Logger::Get()->Log(LogLevel::INFO, "successfully created emoji with id '{}'", id);
+	return id;
+}
+
+bool EmojiManager::DeleteEmoji(EmojiId_t id)
+{
+	if (m_Emojis.find(id) == m_Emojis.end())
+	{
+		Logger::Get()->Log(LogLevel::WARNING, "attempted to delete emoji with id '{}' but it does not exist", id);
+		return false;
+	}
+
+	m_Emojis.erase(id);
+	Logger::Get()->Log(LogLevel::INFO, "successfully deleted emoji with id '{}'", id);
+	return true;
+}
+
+Emoji_t const& EmojiManager::FindEmoji(EmojiId_t id)
+{
+	static Emoji_t invalid_embed;
+	auto it = m_Emojis.find(id);
+	if (it == m_Emojis.end())
+		return invalid_embed;
+	return it->second;
+}

--- a/src/Emoji.hpp
+++ b/src/Emoji.hpp
@@ -38,8 +38,6 @@ private:
 	~EmojiManager() = default;
 
 private:
-	const unsigned int m_InitValue = 1;
-	std::atomic<unsigned int> m_Initialized{ 0 };
 	std::map<EmojiId_t, Emoji_t> m_Emojis;
 public:
 	EmojiId_t AddEmoji(Snowflake_t const & snowflake, std::string const & name);

--- a/src/Emoji.hpp
+++ b/src/Emoji.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Singleton.hpp"
+#include "types.hpp"
+
+#include <string>
+#include <atomic>
+#include <vector>
+#include <json.hpp>
+
+using json = nlohmann::json;
+
+class Emoji
+{
+public:
+	Emoji(Snowflake_t const & id, std::string const & name);
+	~Emoji() = default;
+
+	inline Snowflake_t const& GetSnowflake()
+	{
+		return _id;
+	}
+	inline std::string const& GetName()
+	{
+		return _name;
+	}
+private:
+	Snowflake_t _id;
+	std::string _name;
+
+};
+
+class EmojiManager : public Singleton<EmojiManager>
+{
+	friend class Singleton<EmojiManager>;
+private:
+	EmojiManager() = default;
+	~EmojiManager() = default;
+
+private:
+	const unsigned int m_InitValue = 1;
+	std::atomic<unsigned int> m_Initialized{ 0 };
+	std::map<EmojiId_t, Emoji_t> m_Emojis;
+public:
+	EmojiId_t AddEmoji(Snowflake_t const & snowflake, std::string const & name);
+	bool DeleteEmoji(EmojiId_t id);
+	Emoji_t const& FindEmoji(EmojiId_t id);
+};

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -208,7 +208,7 @@ void Http::NetworkThreadFunc()
 							it_r->value().to_string(),
 							timepoint_now.count());
 						TimePoint_t reset_time = std::chrono::steady_clock::now()
-							+ std::chrono::milliseconds(milliseconds.count() + 500); // add a buffer of 500 ms
+							+ std::chrono::milliseconds(milliseconds.count() + 250); // add a buffer of 250 ms
 
 						bucket_ratelimit.insert({ bucket, reset_time });
 					}

--- a/src/Http.cpp
+++ b/src/Http.cpp
@@ -6,7 +6,6 @@
 #include <boost/asio/system_timer.hpp>
 #include <boost/beast/version.hpp>
 
-
 Http::Http(std::string token) :
 	m_SslContext(asio::ssl::context::tlsv12_client),
 	m_Token(token),
@@ -27,12 +26,57 @@ Http::~Http()
 		delete entry;
 }
 
+void Http::AddBucketIdentifierFromURL(std::string url, std::string bucket)
+{
+	std::string reduced_url = "";
+	// Remove IDs from the string
+	while (url.find("/") != std::string::npos)
+	{
+		std::string part = url.substr(0, url.find("/", 1));
+
+		if (part.find_first_of("0123456789") == std::string::npos)
+		{
+			reduced_url += part;
+		}
+
+		url.erase(0, url.find("/", 1));
+	}
+
+	if (bucket_urls.find(reduced_url) == bucket_urls.end())
+	{
+		bucket_urls.insert({ reduced_url, bucket });
+	}
+}
+
+std::string const Http::GetBucketIdentifierFromURL(std::string url)
+{
+	std::string reduced_url = "";
+	// Remove IDs from the string
+	while (url.find("/") != std::string::npos)
+	{
+		std::string part = url.substr(0, url.find("/", 1));
+
+		if (part.find_first_of("0123456789") == std::string::npos)
+		{
+			reduced_url += part;
+		}
+
+		url.erase(0, url.find("/", 1));
+	}
+
+	if (bucket_urls.find(reduced_url) != bucket_urls.end())
+	{
+		return bucket_urls.at(reduced_url);
+	}
+	return "INVALID";
+}
+
 void Http::NetworkThreadFunc()
 {
-	std::unordered_map<std::string, TimePoint_t> path_ratelimit;
 	unsigned int retry_counter = 0;
 	unsigned int const MaxRetries = 3;
 	bool skip_entry = false;
+	std::unordered_map<std::string, TimePoint_t> bucket_ratelimit;
 
 	if (!Connect())
 		return;
@@ -41,15 +85,15 @@ void Http::NetworkThreadFunc()
 	{
 		TimePoint_t current_time = std::chrono::steady_clock::now();
 		std::list<QueueEntry*> skipped_entries;
-
 		QueueEntry *entry;
 		while (m_Queue.pop(entry))
 		{
 			// check if we're rate-limited
-			auto pr_it = path_ratelimit.find(entry->Request->target().to_string());
-			if (pr_it != path_ratelimit.end())
+			std::string bucket = GetBucketIdentifierFromURL(entry->Request->target().to_string());
+			auto pr_it = bucket_ratelimit.find(bucket);
+			if (pr_it != bucket_ratelimit.end() && bucket != "INVALID")
 			{
-				// rate-limit for this path exists
+				// rate-limit for this bucket exists
 				// are we still within the rate-limit timepoint?
 				if (current_time < pr_it->second)
 				{
@@ -59,8 +103,8 @@ void Http::NetworkThreadFunc()
 				}
 
 				// no, delete rate-limit and go on
-				path_ratelimit.erase(pr_it);
-				Logger::Get()->Log(LogLevel::DEBUG, "rate-limit on path '{}' lifted",
+				bucket_ratelimit.erase(pr_it);
+				Logger::Get()->Log(LogLevel::DEBUG, "rate-limit on bucket '{}' lifted",
 					entry->Request->target().to_string());
 			}
 
@@ -114,24 +158,34 @@ void Http::NetworkThreadFunc()
 			auto it_r = response.find("X-RateLimit-Remaining");
 			if (it_r != response.end())
 			{
+				auto bucket_identifier = response.find("X-RateLimit-Bucket");
+				if (bucket_identifier != response.end())
+				{
+					if (bucket_urls.find(bucket_identifier->value().to_string()) == bucket_urls.end())
+					{
+						//Logger::Get()->Log(LogLevel::ERROR, "{}", entry->Request->target().to_string());
+						AddBucketIdentifierFromURL(entry->Request->target().to_string(), bucket_identifier->value().to_string());
+					}
+				}
+
+				bucket = GetBucketIdentifierFromURL(entry->Request->target().to_string());
 				if (it_r->value().compare("0") == 0)
 				{
 					// we're now officially rate-limited
 					// the next call to this path will fail
-					std::string limited_url = entry->Request->target().to_string();
-					auto lit = path_ratelimit.find(limited_url);
-					if (lit != path_ratelimit.end())
+					auto lit = bucket_ratelimit.find(bucket);
+					if (lit != bucket_ratelimit.end())
 					{
 						Logger::Get()->Log(LogLevel::ERROR,
-							"Error while processing rate-limit: already rate-limited path '{}'",
-							limited_url);
+							"Error while processing rate-limit: already rate-limited bucket '{}'",
+							bucket);
 
 						// skip this request, we'll re-add it to the queue to retry later
 						skipped_entries.push_back(entry);
 						continue;
 					}
 
-					it_r = response.find("X-RateLimit-Reset");
+					it_r = response.find("X-RateLimit-Reset-After");
 					if (it_r != response.end())
 					{
 						string const& reset_time_str = it_r->value().to_string();
@@ -142,21 +196,21 @@ void Http::NetworkThreadFunc()
 						// we have milliseconds too.
 						if (reset_time_str.find(".") != std::string::npos)
 						{
-							const std::string msstr = reset_time_str.substr(reset_time_str.find("."));
+							const std::string msstr = reset_time_str.substr(reset_time_str.find(".")+1);
 							long ms;
 							ConvertStrToData(msstr, ms);
 							milliseconds += std::chrono::milliseconds(ms);
 						}
 
 						std::chrono::milliseconds timepoint_now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
-						Logger::Get()->Log(LogLevel::DEBUG, "rate-limiting path {} until {} (current time: {})",
-							limited_url,
+						Logger::Get()->Log(LogLevel::DEBUG, "rate-limiting bucket {} until {} (current time: {})",
+							bucket,
 							it_r->value().to_string(),
 							timepoint_now.count());
 						TimePoint_t reset_time = std::chrono::steady_clock::now()
-							+ std::chrono::milliseconds(milliseconds.count() - timepoint_now.count() + 1000); // add a buffer of 1 second
+							+ std::chrono::milliseconds(milliseconds.count() + 500); // add a buffer of 500 ms
 
-						path_ratelimit.insert({ limited_url, reset_time });
+						bucket_ratelimit.insert({ bucket, reset_time });
 					}
 				}
 			}

--- a/src/Http.hpp
+++ b/src/Http.hpp
@@ -73,8 +73,11 @@ private:
 	> m_Queue;
 	std::atomic<bool> m_NetworkThreadRunning;
 	std::thread m_NetworkThread;
+	std::map<std::string, std::string> bucket_urls;
 
 private: // functions
+	void AddBucketIdentifierFromURL(std::string url, std::string bucket);
+	std::string const GetBucketIdentifierFromURL(std::string url);
 	void NetworkThreadFunc();
 
 	bool Connect();

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -244,25 +244,23 @@ void MessageManager::Initialize()
 
 	Network::Get()->WebSocket().RegisterEvent(WebSocket::Event::MESSAGE_REACTION_ADD, [](json const& data)
 	{
-		Snowflake_t user_id, message_id;
+		Snowflake_t user_id, message_id, emoji_id;
+		std::string name;
 		if (!utils::TryGetJsonValue(data, user_id, "user_id"))
 			return;
 
 		if (!utils::TryGetJsonValue(data, message_id, "message_id"))
 			return;
+		if (!utils::TryGetJsonValue(data, name, "emoji", "name"))
+			return;
+		utils::TryGetJsonValue(data, emoji_id, "emoji", "id");
 
-		PawnDispatcher::Get()->Dispatch([data, user_id, message_id]() mutable
+		PawnDispatcher::Get()->Dispatch([user_id, message_id, emoji_id, name]() mutable
 		{
 			auto const& msg = MessageManager::Get()->FindById(message_id);
 			auto const& user = UserManager::Get()->FindUserById(user_id);
 			if (msg && user)
 			{
-				Snowflake_t emoji_id;
-				std::string name;
-				utils::TryGetJsonValue(data["emoji"], emoji_id, "id");
-				if (!utils::TryGetJsonValue(data["emoji"], name, "name"))
-					return;
-
 				auto const id = EmojiManager::Get()->AddEmoji(emoji_id, name);
 				// forward DCC_OnMessageReactionAdd(DCC_Message:message, DCC_User:reaction_user, DCC_Emoji:emoji, DCC_MessageReactionType:reaction_type);
 				pawn_cb::Error error;
@@ -274,25 +272,24 @@ void MessageManager::Initialize()
 
 	Network::Get()->WebSocket().RegisterEvent(WebSocket::Event::MESSAGE_REACTION_REMOVE, [](json const& data)
 	{
-		Snowflake_t user_id, message_id;
+		Snowflake_t user_id, message_id, emoji_id;
+		std::string name;
 		if (!utils::TryGetJsonValue(data, user_id, "user_id"))
 			return;
 
 		if (!utils::TryGetJsonValue(data, message_id, "message_id"))
 			return;
 
-		PawnDispatcher::Get()->Dispatch([data, user_id, message_id]() mutable
+		if (!utils::TryGetJsonValue(data, name, "emoji", "name"))
+			return;
+		utils::TryGetJsonValue(data, emoji_id, "emoji", "id");
+
+		PawnDispatcher::Get()->Dispatch([data, user_id, message_id, emoji_id, name]() mutable
 		{
 			auto const& msg = MessageManager::Get()->FindById(message_id);
 			auto const& user = UserManager::Get()->FindUserById(user_id);
 			if (msg && user)
 			{
-				Snowflake_t emoji_id;
-				std::string name;
-				utils::TryGetJsonValue(data["emoji"], emoji_id, "id");
-				if (!utils::TryGetJsonValue(data["emoji"], name, "name"))
-					return;
-
 				auto const id = EmojiManager::Get()->AddEmoji(emoji_id, name);
 				// forward DCC_OnMessageReactionAdd(DCC_Message:message, DCC_User:reaction_user, DCC_Emoji:emoji, DCC_MessageReactionType:reaction_type);
 				pawn_cb::Error error;
@@ -323,22 +320,20 @@ void MessageManager::Initialize()
 
 	Network::Get()->WebSocket().RegisterEvent(WebSocket::Event::MESSAGE_REACTION_REMOVE_EMOJI, [](json const& data)
 	{
-		Snowflake_t  message_id;
+		Snowflake_t  message_id, emoji_id;
+		std::string name;
 
 		if (!utils::TryGetJsonValue(data, message_id, "message_id"))
 			return;
+		if (!utils::TryGetJsonValue(data, name, "emoji", "name"))
+			return;
+		utils::TryGetJsonValue(data, emoji_id, "emoji", "id");
 
-		PawnDispatcher::Get()->Dispatch([data, message_id]() mutable
+		PawnDispatcher::Get()->Dispatch([message_id, emoji_id, name]() mutable
 		{
 			auto const& msg = MessageManager::Get()->FindById(message_id);
 			if (msg)
 			{
-				Snowflake_t emoji_id;
-				std::string name;
-				utils::TryGetJsonValue(data["emoji"], emoji_id, "id");
-				if (!utils::TryGetJsonValue(data["emoji"], name, "name"))
-					return;
-
 				auto const id = EmojiManager::Get()->AddEmoji(emoji_id, name);
 				// forward DCC_OnMessageReactionAdd(DCC_Message:message, DCC_User:reaction_user, DCC_Emoji:emoji, DCC_MessageReactionType:reaction_type);
 				pawn_cb::Error error;

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -194,7 +194,7 @@ void Message::EditEmbeddedMessage(const Embed_t& embed, const std::string & msg)
 		return;
 
 	json data = {
-		{ "content", std::move(msg) },
+		{ "content", msg },
 		{ "embed", {
 			{ "title", embed->GetTitle() },
 			{ "description", embed->GetDescription() },

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -2,6 +2,8 @@
 
 #include "types.hpp"
 #include "Singleton.hpp"
+#include "PawnDispatcher.hpp"
+#include "Callback.hpp"
 
 #include <string>
 #include <vector>
@@ -36,6 +38,8 @@ private:
 	std::vector<RoleId_t> m_RoleMentions;
 
 	bool _valid;
+
+	bool m_Persistent;
 
 	enum class ReactionType : int
 	{
@@ -81,6 +85,10 @@ public:
 	{
 		return m_RoleMentions;
 	}
+	bool Persistent() const
+	{
+		return m_Persistent;
+	}
 
 	bool IsValid() const
 	{
@@ -95,6 +103,7 @@ public:
 	void AddReaction(Emoji_t const& emoji);
 	bool DeleteReaction(EmojiId_t const emojiid);
 	bool EditMessage(const std::string& msg, const EmbedId_t embedid = INVALID_EMBED_ID);
+	void SetPresistent(bool persistent) { m_Persistent = persistent; };
 };
 
 
@@ -124,6 +133,9 @@ public:
 
 	MessageId_t Create(json const &data);
 	bool Delete(MessageId_t id);
+
+	// This is for the cache.
+	void CreateFromSnowflake(Snowflake_t channel, Snowflake_t message, pawn_cb::Callback_t&& callback);
 
 	Message_t const &Find(MessageId_t id);
 	Message_t const &FindById(Snowflake_t const &sfid);

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -86,6 +86,8 @@ public:
 
 	void DeleteMessage();
 	void AddReaction(Emoji_t const& emoji);
+	void EditMessage(const std::string& msg);
+	void EditEmbeddedMessage(const Embed_t& embed, const std::string& msg);
 };
 
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -93,8 +93,8 @@ public:
 
 	void DeleteMessage();
 	void AddReaction(Emoji_t const& emoji);
-	void DeleteReaction(EmojiId_t const emojiid);
-	void EditMessage(const std::string& msg, const EmbedId_t embedid = INVALID_EMBED_ID);
+	bool DeleteReaction(EmojiId_t const emojiid);
+	bool EditMessage(const std::string& msg, const EmbedId_t embedid = INVALID_EMBED_ID);
 };
 
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -86,8 +86,7 @@ public:
 
 	void DeleteMessage();
 	void AddReaction(Emoji_t const& emoji);
-	void EditMessage(const std::string& msg);
-	void EditEmbeddedMessage(const Embed_t& embed, const std::string& msg);
+	void EditMessage(const std::string& msg, const EmbedId_t embedid = INVALID_EMBED_ID);
 };
 
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -85,6 +85,7 @@ public:
 	}
 
 	void DeleteMessage();
+	void AddReaction(Emoji_t const& emoji);
 };
 
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -93,6 +93,7 @@ public:
 
 	void DeleteMessage();
 	void AddReaction(Emoji_t const& emoji);
+	void DeleteReaction(EmojiId_t const emojiid);
 	void EditMessage(const std::string& msg, const EmbedId_t embedid = INVALID_EMBED_ID);
 };
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -37,6 +37,13 @@ private:
 
 	bool _valid;
 
+	enum class ReactionType : int
+	{
+		REACTION_ADD = 0, // Sent when a user adds a reaction to a message.
+		REACTION_REMOVE, // Sent when a user removes a reaction from a message.
+		REACTION_REMOVE_ALL, // Sent when a user explicitly removes all reactions from a message.
+		REACTION_REMOVE_EMOJI // Sent when a bot removes all instances of a given emoji from the reactions of a message.
+	};
 public:
 	Snowflake_t const &GetId() const
 	{

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -250,6 +250,8 @@ extern "C" const AMX_NATIVE_INFO native_list[] =
 	AMX_DEFINE_NATIVE(DCC_SetEmbedFooter)
 	AMX_DEFINE_NATIVE(DCC_SetEmbedThumbnail)
 	AMX_DEFINE_NATIVE(DCC_SetEmbedImage)
+
+	AMX_DEFINE_NATIVE(DCC_DeleteInternalMessage)
 	{ NULL, NULL }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,6 +258,8 @@ extern "C" const AMX_NATIVE_INFO native_list[] =
 	AMX_DEFINE_NATIVE(DCC_GetEmojiName)
 
 	AMX_DEFINE_NATIVE(DCC_CreateReaction)
+
+	AMX_DEFINE_NATIVE(DCC_EditMessage)
 	{ NULL, NULL }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,6 +252,12 @@ extern "C" const AMX_NATIVE_INFO native_list[] =
 	AMX_DEFINE_NATIVE(DCC_SetEmbedImage)
 
 	AMX_DEFINE_NATIVE(DCC_DeleteInternalMessage)
+
+	AMX_DEFINE_NATIVE(DCC_CreateEmoji)
+	AMX_DEFINE_NATIVE(DCC_DeleteEmoji)
+	AMX_DEFINE_NATIVE(DCC_GetEmojiName)
+
+	AMX_DEFINE_NATIVE(DCC_CreateReaction)
 	{ NULL, NULL }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,6 +258,7 @@ extern "C" const AMX_NATIVE_INFO native_list[] =
 	AMX_DEFINE_NATIVE(DCC_GetEmojiName)
 
 	AMX_DEFINE_NATIVE(DCC_CreateReaction)
+	AMX_DEFINE_NATIVE(DCC_DeleteMessageReaction)
 
 	AMX_DEFINE_NATIVE(DCC_EditMessage)
 	{ NULL, NULL }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,6 +261,8 @@ extern "C" const AMX_NATIVE_INFO native_list[] =
 	AMX_DEFINE_NATIVE(DCC_DeleteMessageReaction)
 
 	AMX_DEFINE_NATIVE(DCC_EditMessage)
+	AMX_DEFINE_NATIVE(DCC_SetMessagePersistent)
+	AMX_DEFINE_NATIVE(DCC_CacheChannelMessage)
 	{ NULL, NULL }
 };
 

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -2615,6 +2615,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedThumbnail)
 	return 1;
 }
 
+// native DCC_SetEmbedImage(DCC_Embed:embed, const image_url[]);
 AMX_DECLARE_NATIVE(Native::DCC_SetEmbedImage)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_SetEmbedImage", params, "ds");
@@ -2628,6 +2629,22 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedImage)
 
 	auto const url = amx_GetCppString(amx, params[2]);
 	embed->SetImageUrl(url);
+	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
+	return 1;
+}
+
+// native DCC_DeleteInternalMessage(DCC_Message:message);
+AMX_DECLARE_NATIVE(Native::DCC_DeleteInternalMessage)
+{
+	ScopedDebugInfo dbg_info(amx, "DCC_DeleteInternalMessage", params, "d");
+	auto messageid = static_cast<MessageId_t>(params[1]);
+	auto& message = MessageManager::Get()->Find(messageid);
+	if (!message)
+	{
+		Logger::Get()->LogNative(LogLevel::ERROR, "invalid message id '{}'", messageid);
+		return 0;
+	}
+	MessageManager::Get()->Delete(messageid);
 	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
 	return 1;
 }

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -2732,6 +2732,24 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateReaction)
 	return 1;
 }
 
+// native DCC_DeleteMessageReaction(DCC_Message:message, DCC_Emoji:emoji = 0);
+AMX_DECLARE_NATIVE(Native::DCC_DeleteMessageReaction)
+{
+	ScopedDebugInfo dbg_info(amx, "DCC_DeleteMessageReactions", params, "dd");
+	const auto& messageid = static_cast<MessageId_t>(params[1]);
+	const auto& message = MessageManager::Get()->Find(messageid);
+	if (!message)
+	{
+		Logger::Get()->LogNative(LogLevel::ERROR, "invalid message id '{}'", messageid);
+		return 0;
+	}
+
+	const auto& emojid = static_cast<EmojiId_t>(params[2]);
+	message->DeleteReaction(emojid);
+	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
+	return 1;
+}
+
 // native DCC_EditMessage(DCC_Message:message, const message[], DCC_Embed:embed = 0);
 AMX_DECLARE_NATIVE(Native::DCC_EditMessage)
 {

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -2731,3 +2731,39 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateReaction)
 	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
 	return 1;
 }
+
+// native DCC_EditMessage(DCC_Message:message, const message[], DCC_Embed:embed = 0);
+AMX_DECLARE_NATIVE(Native::DCC_EditMessage)
+{
+	ScopedDebugInfo dbg_info(amx, "DCC_EditMessage", params, "dsd");
+	const auto& messageid = static_cast<MessageId_t>(params[1]);
+	const auto& message = MessageManager::Get()->Find(messageid);
+	if (!message)
+	{
+		Logger::Get()->LogNative(LogLevel::ERROR, "invalid message id '{}'", messageid);
+		return 0;
+	}
+
+	const auto content = amx_GetCppString(amx, params[2]);
+	if (content.length() > 2000)
+	{
+		Logger::Get()->LogNative(LogLevel::ERROR,
+			"message must be shorter than 2000 characters");
+		return 0;
+	}
+
+	const auto& embedid = static_cast<EmbedId_t>(params[3]);
+	const auto& embed = EmbedManager::Get()->FindEmbed(embedid);
+	if (embed)
+	{
+		message->EditEmbeddedMessage(embed, content);
+		EmbedManager::Get()->DeleteEmbed(embedid);
+	}
+	else
+	{
+		message->EditMessage(content);
+	}
+
+	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
+	return 1;
+}

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -2753,16 +2753,7 @@ AMX_DECLARE_NATIVE(Native::DCC_EditMessage)
 	}
 
 	const auto& embedid = static_cast<EmbedId_t>(params[3]);
-	const auto& embed = EmbedManager::Get()->FindEmbed(embedid);
-	if (embed)
-	{
-		message->EditEmbeddedMessage(embed, content);
-		EmbedManager::Get()->DeleteEmbed(embedid);
-	}
-	else
-	{
-		message->EditMessage(content);
-	}
+	message->EditMessage(content, embedid);
 
 	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
 	return 1;

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -2745,9 +2745,9 @@ AMX_DECLARE_NATIVE(Native::DCC_DeleteMessageReaction)
 	}
 
 	const auto& emojid = static_cast<EmojiId_t>(params[2]);
-	message->DeleteReaction(emojid);
-	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
-	return 1;
+	cell retval = static_cast<cell>(message->DeleteReaction(emojid));
+	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '{}'", retval);
+	return retval;
 }
 
 // native DCC_EditMessage(DCC_Message:message, const message[], DCC_Embed:embed = 0);
@@ -2771,8 +2771,8 @@ AMX_DECLARE_NATIVE(Native::DCC_EditMessage)
 	}
 
 	const auto& embedid = static_cast<EmbedId_t>(params[3]);
-	message->EditMessage(content, embedid);
+	cell retval = static_cast<cell>(message->EditMessage(content, embedid));
 
-	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '1'");
-	return 1;
+	Logger::Get()->LogNative(LogLevel::DEBUG, "return value: '{}'", retval);
+	return retval;
 }

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -121,4 +121,7 @@ namespace Native
 	AMX_DECLARE_NATIVE(DCC_SetEmbedFooter);
 	AMX_DECLARE_NATIVE(DCC_SetEmbedThumbnail);
 	AMX_DECLARE_NATIVE(DCC_SetEmbedImage);
+
+	AMX_DECLARE_NATIVE(DCC_DeleteInternalMessage);
+
 }

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -132,4 +132,6 @@ namespace Native
 	AMX_DECLARE_NATIVE(DCC_DeleteMessageReaction);
 
 	AMX_DECLARE_NATIVE(DCC_EditMessage);
+	AMX_DECLARE_NATIVE(DCC_SetMessagePersistent);
+	AMX_DECLARE_NATIVE(DCC_CacheChannelMessage);
 }

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -124,4 +124,9 @@ namespace Native
 
 	AMX_DECLARE_NATIVE(DCC_DeleteInternalMessage);
 
+	AMX_DECLARE_NATIVE(DCC_CreateEmoji);
+	AMX_DECLARE_NATIVE(DCC_DeleteEmoji);
+	AMX_DECLARE_NATIVE(DCC_GetEmojiName);
+
+	AMX_DECLARE_NATIVE(DCC_CreateReaction);
 }

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -129,4 +129,6 @@ namespace Native
 	AMX_DECLARE_NATIVE(DCC_GetEmojiName);
 
 	AMX_DECLARE_NATIVE(DCC_CreateReaction);
+
+	AMX_DECLARE_NATIVE(DCC_EditMessage);
 }

--- a/src/natives.hpp
+++ b/src/natives.hpp
@@ -129,6 +129,7 @@ namespace Native
 	AMX_DECLARE_NATIVE(DCC_GetEmojiName);
 
 	AMX_DECLARE_NATIVE(DCC_CreateReaction);
+	AMX_DECLARE_NATIVE(DCC_DeleteMessageReaction);
 
 	AMX_DECLARE_NATIVE(DCC_EditMessage);
 }

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -30,3 +30,7 @@ const RoleId_t INVALID_ROLE_ID = 0;
 using Embed_t = std::unique_ptr<class Embed>;
 using EmbedId_t = cell;
 const EmbedId_t INVALID_EMBED_ID = 0;
+
+using Emoji_t = std::unique_ptr<class Emoji>;
+using EmojiId_t = cell;
+const EmojiId_t INVALID_EMOJI_ID = 0;


### PR DESCRIPTION
This pull requests adds persistent message support (via return 1 in a callback) #122 , reaction support #114 and the ability to edit (your bot's) messages.

Demo:
![](https://i.imgur.com/uBPaqIo.gif)

Code (sscanf required - no need to join a SAMP server though, I commented out the connection checks):
https://gist.github.com/Alasnkz/ea629e62bd0ab509516e1e79f3ad2325

Known issues:
- For some reason the second reaction is ALWAYS rate limited. No clue why, maybe it's because I was sending invalid requests for half a day trying to send a unicode reaction, any help would be appreciated.