### PR TITLE
Fixed an issue where the username was not updated when changed.

### DIFF
--- a/src/Callback.hpp
+++ b/src/Callback.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <vector>
 #include <cstring>
-
+#include <iterator>
 
 namespace pawn_cb
 {

--- a/src/Guild.cpp
+++ b/src/Guild.cpp
@@ -647,7 +647,7 @@ void GuildManager::Initialize()
 			}
 
 			guild->UpdateMember(user->GetPawnId(), data);
-
+			user->Update(data["user"]);
 			// forward DCC_OnGuildMemberUpdate(DCC_Guild:guild, DCC_User:user);
 			pawn_cb::Error error;
 			pawn_cb::Callback::CallFirst(error, "DCC_OnGuildMemberUpdate", guild->GetPawnId(), user->GetPawnId());

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -34,6 +34,12 @@ void User::Update(json const &data)
 
 	utils::TryGetJsonValue(data, m_IsBot, "bot");
 	utils::TryGetJsonValue(data, m_IsVerified, "verified");
+
+	PawnDispatcher::Get()->Dispatch([&]() mutable
+	{
+		pawn_cb::Error error;
+		pawn_cb::Callback::CallFirst(error, "DCC_OnUserUpdate", GetPawnId());
+	});
 }
 
 
@@ -53,8 +59,12 @@ void UserManager::Initialize()
 		m_Initialized++;
 	});
 
+	// Alasnkz: For some reason this does not get called, I assume this is for when we're in a DM rather than a guild?
+	// Being as GUILD_MEMBER_UPDATE also sends the User object.
+/*
 	Network::Get()->WebSocket().RegisterEvent(WebSocket::Event::USER_UPDATE, [](json const &data)
 	{
+
 		Snowflake_t user_id;
 		if (!utils::TryGetJsonValue(data, user_id, "id"))
 		{
@@ -78,7 +88,7 @@ void UserManager::Initialize()
 			pawn_cb::Error error;
 			pawn_cb::Callback::CallFirst(error, "DCC_OnUserUpdate", user->GetPawnId());
 		});
-	});
+	});*/
 }
 
 bool UserManager::IsInitialized()

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -35,7 +35,7 @@ void User::Update(json const &data)
 	utils::TryGetJsonValue(data, m_IsBot, "bot");
 	utils::TryGetJsonValue(data, m_IsVerified, "verified");
 
-	PawnDispatcher::Get()->Dispatch([&]() mutable
+	PawnDispatcher::Get()->Dispatch([this]()
 	{
 		pawn_cb::Error error;
 		pawn_cb::Callback::CallFirst(error, "DCC_OnUserUpdate", GetPawnId());


### PR DESCRIPTION
This PR should fix #126 

During testing, it seems that the USER_UPDATE event was never called for anything, developer docs doesn't say anything about it. I assume it is actually used for when you have a DM conversation with that person possibly. I edited the guild user update to call User update and it now works.