### PR TITLE
Removed parent_id error on channels, they can have no parent (category).

### DIFF
--- a/src/Callback.hpp
+++ b/src/Callback.hpp
@@ -8,7 +8,7 @@
 #include <memory>
 #include <vector>
 #include <cstring>
-
+#include <iterator>
 
 namespace pawn_cb
 {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -61,6 +61,12 @@ void Channel::Update(json const &data)
 
 void Channel::UpdateParentChannel(Snowflake_t const &parent_id)
 {
+	if (parent_id.length() < 1)
+	{
+		m_ParentId = 0;
+		return;
+	}
+
 	Channel_t const &channel = ChannelManager::Get()->FindChannelById(parent_id);
 	if (!channel)
 	{
@@ -300,11 +306,7 @@ void ChannelManager::Initialize()
 			if (channel->GetType() != Channel::Type::GUILD_CATEGORY)
 			{
 				Snowflake_t parent_id;
-				if (!utils::TryGetJsonValue(data, parent_id, "parent_id"))
-				{
-					Logger::Get()->Log(LogLevel::ERROR, "invalid JSON: expected \"parent_id\" in \"{}\"", data.dump());
-					return;
-				}
+				utils::TryGetJsonValue(data, parent_id, "parent_id");
 				channel->UpdateParentChannel(parent_id);
 			}
 

--- a/src/Guild.cpp
+++ b/src/Guild.cpp
@@ -50,11 +50,7 @@ Guild::Guild(GuildId_t pawn_id, json const &data) :
 					continue;
 
 				Snowflake_t parent_id;
-				if (!utils::TryGetJsonValue(c, parent_id, "parent_id"))
-				{
-					Logger::Get()->Log(LogLevel::ERROR, "invalid JSON: expected \"parent_id\" in \"{}\"", c.dump());
-					break;
-				}
+				utils::TryGetJsonValue(data, parent_id, "parent_id");
 				channel->UpdateParentChannel(parent_id);
 			}
 		}

--- a/src/Guild.cpp
+++ b/src/Guild.cpp
@@ -50,7 +50,7 @@ Guild::Guild(GuildId_t pawn_id, json const &data) :
 					continue;
 
 				Snowflake_t parent_id;
-				utils::TryGetJsonValue(data, parent_id, "parent_id");
+				utils::TryGetJsonValue(c, parent_id, "parent_id");
 				channel->UpdateParentChannel(parent_id);
 			}
 		}


### PR DESCRIPTION
Pretty self explanatory, it was complaining about this (very common issue people have), there's no reason to have this.