### PR TITLE
Mention using envvar for bot token in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ How to install
 2. Edit the server configuration (*server.cfg*) as follows:
    - Windows: `plugins discord-connector`
    - Linux: `plugins discord-connector.so`
-3. Add `discord_bot_token YOURDISCORDBOTTOKEN` to your *server.cfg* file (__never share your bot token with anyone!__)
+3. Add `discord_bot_token YOURDISCORDBOTTOKEN` to your *server.cfg* file, or set it in the environment variable `SAMP_DISCORD_BOT_TOKEN` (__never share your bot token with anyone!__)
 
 Build instruction
 ---------------


### PR DESCRIPTION
It's a valid means of using the connector but not mentioned in the readme so far