### PR TITLE
Add Windows-874 (CP874) Pawn encoding + faster startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ How to install on a SA:MP server
    - Linux: `plugins discord-connector.so`
 3. Add `discord_bot_token YOURDISCORDBOTTOKEN` to your *server.cfg* file, or set it in the environment variable `DCC_BOT_TOKEN` (__never share your bot token with anyone!__)
 
+Pawn Encoding / Thai (Windows-874)
+--------------------------------
+If your Pawn scripts are encoded as Windows-874 (Thai), configure the plugin to convert between Windows-874 <-> UTF-8:
+- SA:MP (`server.cfg`): `discord_pawn_encoding windows-874`
+- open.mp (`config.json`): `"discord": { "pawn_encoding": "windows-874" }`
+- Environment variable: `DCC_PAWN_ENCODING=windows-874`
+
+Startup / Initialization Wait
+-----------------------------
+By default the plugin initializes in the background (so it does not delay server startup). If you want to block server startup until Discord data is initialized:
+- SA:MP (`server.cfg`): `discord_init_block_ms 20000`
+- open.mp (`config.json`): `"discord": { "init_block_ms": 20000 }`
+- Environment variable: `DCC_INIT_BLOCK_MS=20000`
+
+If you want to control when the plugin considers initialization "timed out" and starts retrying in the background:
+- `discord_init_timeout_ms` / `discord.init_timeout_ms` / `DCC_INIT_TIMEOUT_MS`
+  Default is `120000` (120 seconds).
+
 I am getting a intent error, how do I fix it?
 ---------------
 If you're getting an intent error, you need to go to the [discord developer dashboard](https://discord.com/developers/applications) and select your bot.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Discord connector plugin for San Andreas Multiplayer (SA:MP)
 
-| AppVeyor CI | Total downloads | Latest release |
+**Language:** English | [ภาษาไทย](README.th.md)
+
+| CI | Total downloads | Latest release |
 | :---: | :---: | :---: |
-|  ![Build status](https://github.com/maddinat0r/samp-discord-connector/workflows/Build/badge.svg)|  [![All Releases](https://img.shields.io/github/downloads/maddinat0r/samp-discord-connector/total.svg?maxAge=86400)](https://github.com/maddinat0r/samp-discord-connector/releases)  |  [![latest release](https://img.shields.io/github/release/maddinat0r/samp-discord-connector.svg?maxAge=86400)](https://github.com/maddinat0r/samp-discord-connector/releases) <br> [![Github Releases](https://img.shields.io/github/downloads/maddinat0r/samp-discord-connector/latest/total.svg?maxAge=86400)](https://github.com/maddinat0r/samp-discord-connector/releases)  |  
+|  [![Build status](https://github.com/GimmickPlus/samp-discord-connector/actions/workflows/build.yml/badge.svg)](https://github.com/GimmickPlus/samp-discord-connector/actions/workflows/build.yml) |  [![All Releases](https://img.shields.io/github/downloads/GimmickPlus/samp-discord-connector/total.svg?maxAge=86400)](https://github.com/GimmickPlus/samp-discord-connector/releases)  |  [![latest release](https://img.shields.io/github/release/GimmickPlus/samp-discord-connector.svg?maxAge=86400)](https://github.com/GimmickPlus/samp-discord-connector/releases) <br> [![Github Releases](https://img.shields.io/github/downloads/GimmickPlus/samp-discord-connector/latest/total.svg?maxAge=86400)](https://github.com/GimmickPlus/samp-discord-connector/releases)  |  
 -------------------------------------------------
 **This plugin allows you to control a Discord bot from within your PAWN script.**
 

--- a/README.th.md
+++ b/README.th.md
@@ -1,0 +1,72 @@
+# Discord connector plugin สำหรับ San Andreas Multiplayer (SA:MP)
+
+**ภาษา:** [English](README.md) | ภาษาไทย
+
+| CI | ดาวน์โหลดทั้งหมด | รีลีสล่าสุด |
+| :---: | :---: | :---: |
+|  [![Build status](https://github.com/GimmickPlus/samp-discord-connector/actions/workflows/build.yml/badge.svg)](https://github.com/GimmickPlus/samp-discord-connector/actions/workflows/build.yml) |  [![All Releases](https://img.shields.io/github/downloads/GimmickPlus/samp-discord-connector/total.svg?maxAge=86400)](https://github.com/GimmickPlus/samp-discord-connector/releases)  |  [![latest release](https://img.shields.io/github/release/GimmickPlus/samp-discord-connector.svg?maxAge=86400)](https://github.com/GimmickPlus/samp-discord-connector/releases) <br> [![Github Releases](https://img.shields.io/github/downloads/GimmickPlus/samp-discord-connector/latest/total.svg?maxAge=86400)](https://github.com/GimmickPlus/samp-discord-connector/releases)  |
+
+-------------------------------------------------
+**ปลั๊กอินนี้ช่วยให้คุณควบคุม Discord bot ได้จากภายในสคริปต์ PAWN ของคุณ**
+
+**วิธีติดตั้งบน open.mp**
+-----------------------------------
+1. แตกไฟล์จาก archive ไปยังโฟลเดอร์ที่ต้องการ แล้วคัดลอกไฟล์ในโฟลเดอร์ `plugins` ไปไว้ใน **COMPONENTS** (ถ้าไม่ทำ open.mp จะพยายามโหลดเป็นปลั๊กอิน SA:MP)
+2. แก้ไขไฟล์ตั้งค่า (**config.json**) เช่น:
+   ```json
+      "discord": {
+         "bot_token": "MYBOTTOKEN"
+      }
+    ```
+   หรือใช้ environment variable **DCC_BOT_TOKEN** แทนได้ (ห้ามแชร์ token ให้ใครเด็ดขาด)
+
+วิธีติดตั้งบน SA:MP
+--------------------------------
+1. แตกไฟล์จาก archive ไปไว้ในโฟลเดอร์หลักของ SA:MP server
+2. แก้ไขไฟล์ `server.cfg`:
+   - Windows: `plugins discord-connector`
+   - Linux: `plugins discord-connector.so`
+3. เพิ่ม `discord_bot_token YOURDISCORDBOTTOKEN` ใน `server.cfg` หรือกำหนดผ่าน environment variable `DCC_BOT_TOKEN` (ห้ามแชร์ token ให้ใครเด็ดขาด)
+
+Pawn Encoding / ภาษาไทย (Windows-874)
+--------------------------------
+ถ้าสคริปต์ Pawn ของคุณเป็น encoding Windows-874 (ไทย) ให้ตั้งค่าเพื่อให้ปลั๊กอินแปลงระหว่าง Windows-874 <-> UTF-8:
+- SA:MP (`server.cfg`): `discord_pawn_encoding windows-874`
+- open.mp (`config.json`): `"discord": { "pawn_encoding": "windows-874" }`
+- Environment variable: `DCC_PAWN_ENCODING=windows-874`
+
+Startup / รอการ Initialize
+-----------------------------
+ค่าเริ่มต้นปลั๊กอินจะ initialize แบบ background (เพื่อไม่ให้ทำให้การเปิดเซิร์ฟช้าลง) หากต้องการให้บล็อกการเริ่มเซิร์ฟเวอร์จนกว่าจะ init ข้อมูล Discord เสร็จ:
+- SA:MP (`server.cfg`): `discord_init_block_ms 20000`
+- open.mp (`config.json`): `"discord": { "init_block_ms": 20000 }`
+- Environment variable: `DCC_INIT_BLOCK_MS=20000`
+
+หากต้องการกำหนดเวลาว่าเมื่อไหร่ถึงจะถือว่า init "timeout" และเริ่ม retry ต่อแบบ background:
+- `discord_init_timeout_ms` / `discord.init_timeout_ms` / `DCC_INIT_TIMEOUT_MS`
+  ค่าเริ่มต้นคือ `120000` (120 วินาที)
+
+ขึ้น intent error ต้องแก้ยังไง?
+---------------
+ถ้าขึ้น intent error ให้เข้าไปที่ [Discord developer dashboard](https://discord.com/developers/applications) เลือกบอทของคุณ จากนั้นไปที่ตั้งค่าบอทและเปิด intents ที่ต้องใช้
+
+วิธี Build
+---------------
+*หมายเหตุ*: ปลั๊กอินต้องเป็นไลบรารี 32-bit ดังนั้นไลบรารีที่เกี่ยวข้องทั้งหมดต้องคอมไพล์แบบ 32-bit และคอมไพเลอร์ต้องรองรับ 32-bit
+
+#### Windows
+1. ติดตั้ง C++ compiler ที่ต้องการ
+2. ติดตั้ง [CMake](http://www.cmake.org/)
+3. ติดตั้ง [Conan](https://conan.io)
+4. clone repository แบบ recursive (`git clone --recursive https://...`)
+5. สร้างโฟลเดอร์ `build` และรัน CMake ในนั้น
+6. build project ที่ generate ขึ้นด้วยคอมไพเลอร์ของคุณ
+
+#### Linux
+1. ติดตั้ง C++ compiler ที่ต้องการ
+2. ติดตั้ง [CMake](http://www.cmake.org/)
+3. ติดตั้ง [Conan](https://conan.io)
+4. clone repository แบบ recursive (`git clone --recursive https://...`)
+5. สร้างโฟลเดอร์ `build` และรัน CMake ในนั้น (`mkdir build && cd build && cmake ..`)
+6. build project ที่ generate ขึ้นด้วยคอมไพเลอร์ของคุณ
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,8 @@ add_samp_plugin(discord-connector
 	Command.hpp
 	CommandInteraction.cpp
 	CommandInteraction.hpp
+	Encoding.cpp
+	Encoding.hpp
 	main.cpp
 	misc.hpp
 	natives.cpp

--- a/src/Encoding.cpp
+++ b/src/Encoding.cpp
@@ -1,0 +1,255 @@
+#include "Encoding.hpp"
+
+#include <atomic>
+#include <cstdint>
+
+namespace utils
+{
+	static std::atomic<int> g_PawnEncoding{ static_cast<int>(PawnEncoding::RAW) };
+
+	void SetPawnEncoding(PawnEncoding enc)
+	{
+		g_PawnEncoding.store(static_cast<int>(enc), std::memory_order_relaxed);
+	}
+
+	PawnEncoding GetPawnEncoding()
+	{
+		return static_cast<PawnEncoding>(g_PawnEncoding.load(std::memory_order_relaxed));
+	}
+
+	static inline void AppendUtf8(std::string& out, uint32_t cp)
+	{
+		if (cp <= 0x7Fu)
+		{
+			out.push_back(static_cast<char>(cp));
+		}
+		else if (cp <= 0x7FFu)
+		{
+			out.push_back(static_cast<char>(0xC0u | ((cp >> 6) & 0x1Fu)));
+			out.push_back(static_cast<char>(0x80u | (cp & 0x3Fu)));
+		}
+		else if (cp <= 0xFFFFu)
+		{
+			out.push_back(static_cast<char>(0xE0u | ((cp >> 12) & 0x0Fu)));
+			out.push_back(static_cast<char>(0x80u | ((cp >> 6) & 0x3Fu)));
+			out.push_back(static_cast<char>(0x80u | (cp & 0x3Fu)));
+		}
+		else if (cp <= 0x10FFFFu)
+		{
+			out.push_back(static_cast<char>(0xF0u | ((cp >> 18) & 0x07u)));
+			out.push_back(static_cast<char>(0x80u | ((cp >> 12) & 0x3Fu)));
+			out.push_back(static_cast<char>(0x80u | ((cp >> 6) & 0x3Fu)));
+			out.push_back(static_cast<char>(0x80u | (cp & 0x3Fu)));
+		}
+		else
+		{
+			out.push_back('?');
+		}
+	}
+
+	static inline uint32_t Cp1252ToUnicode(unsigned char b)
+	{
+		// Only valid for 0x80..0x9F. (Windows-874 shares this range with Windows-1252.)
+		// Undefined bytes are mapped to their C1 control codepoints, which is a reasonable
+		// "lossless" fallback for round-tripping unknown bytes.
+		static const uint32_t table[32] = {
+			0x20ACu, 0x0081u, 0x201Au, 0x0192u, 0x201Eu, 0x2026u, 0x2020u, 0x2021u,
+			0x02C6u, 0x2030u, 0x0160u, 0x2039u, 0x0152u, 0x008Du, 0x017Du, 0x008Fu,
+			0x0090u, 0x2018u, 0x2019u, 0x201Cu, 0x201Du, 0x2022u, 0x2013u, 0x2014u,
+			0x02DCu, 0x2122u, 0x0161u, 0x203Au, 0x0153u, 0x009Du, 0x017Eu, 0x0178u
+		};
+		return table[b - 0x80u];
+	}
+
+	static inline bool UnicodeToCp1252(uint32_t cp, unsigned char& out_b)
+	{
+		switch (cp)
+		{
+		case 0x20ACu: out_b = 0x80u; return true;
+		case 0x201Au: out_b = 0x82u; return true;
+		case 0x0192u: out_b = 0x83u; return true;
+		case 0x201Eu: out_b = 0x84u; return true;
+		case 0x2026u: out_b = 0x85u; return true;
+		case 0x2020u: out_b = 0x86u; return true;
+		case 0x2021u: out_b = 0x87u; return true;
+		case 0x02C6u: out_b = 0x88u; return true;
+		case 0x2030u: out_b = 0x89u; return true;
+		case 0x0160u: out_b = 0x8Au; return true;
+		case 0x2039u: out_b = 0x8Bu; return true;
+		case 0x0152u: out_b = 0x8Cu; return true;
+		case 0x017Du: out_b = 0x8Eu; return true;
+		case 0x2018u: out_b = 0x91u; return true;
+		case 0x2019u: out_b = 0x92u; return true;
+		case 0x201Cu: out_b = 0x93u; return true;
+		case 0x201Du: out_b = 0x94u; return true;
+		case 0x2022u: out_b = 0x95u; return true;
+		case 0x2013u: out_b = 0x96u; return true;
+		case 0x2014u: out_b = 0x97u; return true;
+		case 0x02DCu: out_b = 0x98u; return true;
+		case 0x2122u: out_b = 0x99u; return true;
+		case 0x0161u: out_b = 0x9Au; return true;
+		case 0x203Au: out_b = 0x9Bu; return true;
+		case 0x0153u: out_b = 0x9Cu; return true;
+		case 0x017Eu: out_b = 0x9Eu; return true;
+		case 0x0178u: out_b = 0x9Fu; return true;
+		default: return false;
+		}
+	}
+
+	static std::string Cp874ToUtf8(std::string const& in)
+	{
+		std::string out;
+		out.reserve(in.size() * 2);
+
+		for (unsigned char b : in)
+		{
+			uint32_t cp = 0;
+			if (b < 0x80u)
+			{
+				cp = b;
+			}
+			else if (b >= 0x80u && b <= 0x9Fu)
+			{
+				cp = Cp1252ToUnicode(b);
+			}
+			else if (b == 0xA0u)
+			{
+				cp = 0x00A0u; // NBSP
+			}
+			else if (b >= 0xA1u && b <= 0xFBu)
+			{
+				// Windows-874 maps 0xA1..0xFB to Unicode Thai block U+0E01..U+0E5B.
+				cp = 0x0E01u + (b - 0xA1u);
+			}
+			else if (b >= 0xFCu)
+			{
+				// Remaining 0xFC..0xFF keep Latin-1.
+				cp = 0x00FCu + (b - 0xFCu);
+			}
+			else
+			{
+				// Unspecified byte.
+				cp = '?';
+			}
+
+			AppendUtf8(out, cp);
+		}
+
+		return out;
+	}
+
+	static inline bool NextUtf8Codepoint(std::string const& s, size_t& i, uint32_t& cp)
+	{
+		if (i >= s.size())
+			return false;
+
+		const unsigned char c0 = static_cast<unsigned char>(s[i++]);
+		if (c0 < 0x80u)
+		{
+			cp = c0;
+			return true;
+		}
+
+		// Reject overlongs and invalid sequences; replace with '?'.
+		auto need_cont = [&](int n, uint32_t acc, uint32_t min_cp) -> bool
+		{
+			for (int k = 0; k < n; ++k)
+			{
+				if (i >= s.size())
+					return false;
+				const unsigned char cx = static_cast<unsigned char>(s[i++]);
+				if ((cx & 0xC0u) != 0x80u)
+					return false;
+				acc = (acc << 6) | (cx & 0x3Fu);
+			}
+			if (acc < min_cp || acc > 0x10FFFFu || (acc >= 0xD800u && acc <= 0xDFFFu))
+				return false;
+			cp = acc;
+			return true;
+		};
+
+		if ((c0 & 0xE0u) == 0xC0u)
+			return need_cont(1, c0 & 0x1Fu, 0x80u);
+		if ((c0 & 0xF0u) == 0xE0u)
+			return need_cont(2, c0 & 0x0Fu, 0x800u);
+		if ((c0 & 0xF8u) == 0xF0u)
+			return need_cont(3, c0 & 0x07u, 0x10000u);
+
+		return false;
+	}
+
+	static std::string Utf8ToCp874(std::string const& in)
+	{
+		std::string out;
+		out.reserve(in.size());
+
+		size_t i = 0;
+		while (i < in.size())
+		{
+			uint32_t cp = 0;
+			size_t prev = i;
+			if (!NextUtf8Codepoint(in, i, cp))
+			{
+				// Invalid UTF-8 byte, consume one and replace.
+				i = prev + 1;
+				out.push_back('?');
+				continue;
+			}
+
+			if (cp <= 0x7Fu)
+			{
+				out.push_back(static_cast<char>(cp));
+				continue;
+			}
+
+			// Thai block
+			if (cp >= 0x0E01u && cp <= 0x0E5Bu)
+			{
+				out.push_back(static_cast<char>(0xA1u + (cp - 0x0E01u)));
+				continue;
+			}
+
+			// NBSP
+			if (cp == 0x00A0u)
+			{
+				out.push_back(static_cast<char>(0xA0u));
+				continue;
+			}
+
+			// Keep 0xFC..0xFF Latin-1
+			if (cp >= 0x00FCu && cp <= 0x00FFu)
+			{
+				out.push_back(static_cast<char>(0xFCu + (cp - 0x00FCu)));
+				continue;
+			}
+
+			// Windows-1252 special punctuation range
+			unsigned char b = 0;
+			if (UnicodeToCp1252(cp, b))
+			{
+				out.push_back(static_cast<char>(b));
+				continue;
+			}
+
+			// Not representable in Windows-874.
+			out.push_back('?');
+		}
+
+		return out;
+	}
+
+	std::string FromPawnEncoding(std::string s)
+	{
+		if (GetPawnEncoding() == PawnEncoding::WINDOWS_874)
+			return Cp874ToUtf8(s);
+		return s;
+	}
+
+	std::string ToPawnEncoding(std::string const& utf8)
+	{
+		if (GetPawnEncoding() == PawnEncoding::WINDOWS_874)
+			return Utf8ToCp874(utf8);
+		return utf8;
+	}
+}
+

--- a/src/Encoding.hpp
+++ b/src/Encoding.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+namespace utils
+{
+	// Encoding of Pawn script strings as seen by the plugin.
+	// RAW means: no conversion is performed (treat bytes as UTF-8 already).
+	// WINDOWS_874 means: Pawn provides/consumes Windows-874 (CP874) byte strings.
+	enum class PawnEncoding
+	{
+		RAW = 0,
+		WINDOWS_874 = 874
+	};
+
+	void SetPawnEncoding(PawnEncoding enc);
+	PawnEncoding GetPawnEncoding();
+
+	// Convert Pawn bytes -> UTF-8 for Discord/JSON.
+	// If encoding is RAW, this returns the input unchanged.
+	std::string FromPawnEncoding(std::string s);
+
+	// Convert UTF-8 -> Pawn bytes for returning strings to Pawn.
+	// If encoding is RAW, this returns the input unchanged.
+	std::string ToPawnEncoding(std::string const& utf8);
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,13 @@
 #include "SampConfigReader.hpp"
 #include "Logger.hpp"
 #include "version.hpp"
+#include "Encoding.hpp"
 
 #include <samplog/samplog.hpp>
 #include <thread>
 #include <cstdlib>
+#include <algorithm>
+#include <cctype>
 #include <sdk.hpp>
 #include <Server/Components/Pawn/pawn.hpp>
 
@@ -40,25 +43,76 @@ void DestroyEverything()
 	Network::Singleton::Destroy();
 }
 
-bool WaitForInitialization()
+static bool EverythingInitialized()
+{
+	return GuildManager::Get()->IsInitialized()
+		&& UserManager::Get()->IsInitialized()
+		&& ChannelManager::Get()->IsInitialized()
+		&& CommandManager::Get()->IsInitialized();
+}
+
+static bool ReadySeen()
+{
+	// READY sets initialized=1 on these managers. GuildManager may take much longer
+	// because it waits for GUILD_CREATE events for all guilds.
+	return UserManager::Get()->IsInitialized()
+		&& ChannelManager::Get()->IsInitialized()
+		&& CommandManager::Get()->IsInitialized();
+}
+
+static unsigned int ParseUIntOrDefault(std::string const &s, unsigned int def)
+{
+	if (s.empty())
+		return def;
+	try
+	{
+		auto v = std::stoul(s);
+		if (v > 0xFFFFFFFFu)
+			return def;
+		return static_cast<unsigned int>(v);
+	}
+	catch (...)
+	{
+		return def;
+	}
+}
+
+static utils::PawnEncoding ParsePawnEncoding(std::string s)
+{
+	std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c)
+	{
+		return static_cast<char>(std::tolower(c));
+	});
+
+	if (s == "cp874" || s == "windows-874" || s == "windows_874" || s == "win874" || s == "874")
+		return utils::PawnEncoding::WINDOWS_874;
+
+	// default: assume Pawn strings are already UTF-8 (or user wants raw bytes).
+	return utils::PawnEncoding::RAW;
+}
+
+static void ConfigurePawnEncoding(std::string const &encoding_str)
+{
+	utils::SetPawnEncoding(ParsePawnEncoding(encoding_str));
+}
+
+bool WaitForInitialization(unsigned int timeout_ms)
 {
 	unsigned int const
-		SLEEP_TIME_MS = 20,
-		TIMEOUT_TIME_MS = 20 * 1000;
+		SLEEP_TIME_MS = 20;
 	unsigned int waited_time = 0;
+
+	if (timeout_ms == 0)
+		return EverythingInitialized();
+
 	while (true)
 	{
-		if (GuildManager::Get()->IsInitialized()
-			&& UserManager::Get()->IsInitialized()
-			&& ChannelManager::Get()->IsInitialized()
-			&& CommandManager::Get()->IsInitialized())
-		{
+		if (EverythingInitialized())
 			return true;
-		}
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(SLEEP_TIME_MS));
 		waited_time += SLEEP_TIME_MS;
-		if (waited_time > TIMEOUT_TIME_MS)
+		if (waited_time > timeout_ms)
 			break;
 	}
 	return false;
@@ -122,32 +176,83 @@ PLUGIN_EXPORT bool PLUGIN_CALL Load(void **ppData)
 
 	if (!bot_token.empty())
 	{
+		// Configure Pawn string encoding (default RAW/UTF-8).
+		{
+			auto enc = GetEnvironmentVar("DCC_PAWN_ENCODING");
+			if (enc.empty())
+				SampConfigReader::Get()->GetVar("discord_pawn_encoding", enc);
+			ConfigurePawnEncoding(enc);
+		}
+
+		unsigned int init_block_ms = 0;
+		unsigned int init_timeout_ms = 120 * 1000;
+		{
+			auto s = GetEnvironmentVar("DCC_INIT_BLOCK_MS");
+			if (s.empty())
+				SampConfigReader::Get()->GetVar("discord_init_block_ms", s);
+			init_block_ms = ParseUIntOrDefault(s, 0);
+
+			s = GetEnvironmentVar("DCC_INIT_TIMEOUT_MS");
+			if (s.empty())
+				SampConfigReader::Get()->GetVar("discord_init_timeout_ms", s);
+			init_timeout_ms = ParseUIntOrDefault(s, 120 * 1000);
+		}
+
 		InitializeEverything(bot_token, intents);
 
-		if (WaitForInitialization())
+		// Watchdog/retry thread (non-blocking): if initialization doesn't complete in time,
+		// retry connecting in the background. Important: re-check before destroying, to avoid
+		// tearing down a slow-but-successful initialization.
+		if (init_timeout_ms > 0)
 		{
-			logprintf(" >> discord-connector: " PLUGIN_VERSION " successfully loaded.");
-		}
-		else
-		{
-			logprintf(" >> discord-connector: timeout while initializing data.");
-
-			std::thread init_thread([bot_token, intents]()
+			std::thread init_thread([bot_token, intents, init_timeout_ms]()
 			{
+				if (WaitForInitialization(init_timeout_ms))
+					return;
+
+				// If READY was received, we're likely just caching large guild state.
+				if (ReadySeen())
+				{
+					logprintf(" >> discord-connector: initialization still in progress after %u ms; continuing in background.", init_timeout_ms);
+					while (!EverythingInitialized())
+						std::this_thread::sleep_for(std::chrono::seconds(1));
+					logprintf(" >> discord-connector: initialization completed.");
+					return;
+				}
+
+				logprintf(" >> discord-connector: timeout while connecting (no READY after %u ms).", init_timeout_ms);
+				logprintf("                         plugin will proceed to retry connecting in the background.");
+
 				while (true)
 				{
 					std::this_thread::sleep_for(std::chrono::minutes(1));
 
+					// If READY happens while we're waiting, don't tear down; just keep waiting.
+					if (ReadySeen())
+					{
+						while (!EverythingInitialized())
+							std::this_thread::sleep_for(std::chrono::seconds(1));
+						break;
+					}
+
+					if (EverythingInitialized())
+						break;
+
 					DestroyEverything();
 					InitializeEverything(bot_token, intents);
-					if (WaitForInitialization())
+
+					if (WaitForInitialization(init_timeout_ms))
 						break;
 				}
 			});
 			init_thread.detach();
-
-			logprintf("                         plugin will proceed to retry connecting in the background.");
 		}
+
+		// Optional blocking wait to delay server startup until ready (backwards-compatible behavior).
+		if (init_block_ms > 0 && WaitForInitialization(init_block_ms))
+			logprintf(" >> discord-connector: " PLUGIN_VERSION " successfully loaded.");
+		else
+			logprintf(" >> discord-connector: " PLUGIN_VERSION " loaded (initializing in background).");
 	}
 	else
 	{
@@ -407,32 +512,89 @@ class DiscordComponent : public IComponent, public PawnEventHandler, public Core
 
 		if (!bot_token.empty())
 		{
+			// Configure Pawn string encoding (default RAW/UTF-8).
+			{
+				std::string enc = GetEnvironmentVar("DCC_PAWN_ENCODING");
+				if (enc.empty())
+				{
+					auto cfg_enc = core->getConfig().getString("discord.pawn_encoding");
+					if (!cfg_enc.empty())
+						enc = cfg_enc.data();
+				}
+				ConfigurePawnEncoding(enc);
+			}
+
+			unsigned int init_block_ms = 0;
+			unsigned int init_timeout_ms = 120 * 1000;
+			{
+				std::string s = GetEnvironmentVar("DCC_INIT_BLOCK_MS");
+				if (s.empty())
+				{
+					auto cfg = core->getConfig().getInt("discord.init_block_ms");
+					if (cfg)
+						s = std::to_string(*cfg);
+				}
+				init_block_ms = ParseUIntOrDefault(s, 0);
+
+				s = GetEnvironmentVar("DCC_INIT_TIMEOUT_MS");
+				if (s.empty())
+				{
+					auto cfg = core->getConfig().getInt("discord.init_timeout_ms");
+					if (cfg)
+						s = std::to_string(*cfg);
+				}
+				init_timeout_ms = ParseUIntOrDefault(s, 120 * 1000);
+			}
+
 			InitializeEverything(bot_token.data(), intents);
 
-			if (WaitForInitialization())
+			if (init_timeout_ms > 0)
 			{
-				logprintf(" >> discord-connector: " PLUGIN_VERSION " successfully loaded.");
-			}
-			else
-			{
-				logprintf(" >> discord-connector: timeout while initializing data.");
+				std::thread init_thread([bot_token, intents, init_timeout_ms]()
+				{
+					if (WaitForInitialization(init_timeout_ms))
+						return;
 
-				std::thread init_thread([bot_token, intents]()
+					if (ReadySeen())
 					{
-						while (true)
+						logprintf(" >> discord-connector: initialization still in progress after %u ms; continuing in background.", init_timeout_ms);
+						while (!EverythingInitialized())
+							std::this_thread::sleep_for(std::chrono::seconds(1));
+						logprintf(" >> discord-connector: initialization completed.");
+						return;
+					}
+
+					logprintf(" >> discord-connector: timeout while connecting (no READY after %u ms).", init_timeout_ms);
+					logprintf("                         component will proceed to retry connecting in the background.");
+
+					while (true)
+					{
+						std::this_thread::sleep_for(std::chrono::minutes(1));
+
+						if (ReadySeen())
 						{
-							std::this_thread::sleep_for(std::chrono::minutes(1));
-
-							DestroyEverything();
-							InitializeEverything(bot_token.data(), intents);
-							if (WaitForInitialization())
-								break;
+							while (!EverythingInitialized())
+								std::this_thread::sleep_for(std::chrono::seconds(1));
+							break;
 						}
-					});
-				init_thread.detach();
 
-				logprintf("                         component will proceed to retry connecting in the background.");
+						if (EverythingInitialized())
+							break;
+
+						DestroyEverything();
+						InitializeEverything(bot_token.data(), intents);
+
+						if (WaitForInitialization(init_timeout_ms))
+							break;
+					}
+				});
+				init_thread.detach();
 			}
+
+			if (init_block_ms > 0 && WaitForInitialization(init_block_ms))
+				logprintf(" >> discord-connector: " PLUGIN_VERSION " successfully loaded.");
+			else
+				logprintf(" >> discord-connector: " PLUGIN_VERSION " loaded (initializing in background).");
 		}
 		else
 		{

--- a/src/natives.cpp
+++ b/src/natives.cpp
@@ -14,11 +14,42 @@
 #include "Emoji.hpp"
 #include "Command.hpp"
 #include "CommandInteraction.hpp"
+#include "Encoding.hpp"
 #include <fmt/printf.h>
+#include <unordered_set>
 
 #ifdef ERROR
 #undef ERROR
 #endif
+
+static inline std::string GetPawnStr(AMX *amx, cell param)
+{
+	return utils::FromPawnEncoding(::amx_GetCppString(amx, param));
+}
+
+static inline size_t Utf8CharCount(std::string const &s)
+{
+	// Discord limits are in characters; use a lenient UTF-8 codepoint count.
+	size_t i = 0;
+	size_t count = 0;
+	while (i < s.size())
+	{
+		const unsigned char c = static_cast<unsigned char>(s[i]);
+		if (c < 0x80u)
+			i += 1;
+		else if ((c & 0xE0u) == 0xC0u && i + 1 < s.size())
+			i += 2;
+		else if ((c & 0xF0u) == 0xE0u && i + 2 < s.size())
+			i += 3;
+		else if ((c & 0xF8u) == 0xF0u && i + 3 < s.size())
+			i += 4;
+		else
+			i += 1; // invalid byte
+
+		++count;
+	}
+	return count;
+}
 /*
 // native native_name(...);
 AMX_DECLARE_NATIVE(Native::native_name)
@@ -38,7 +69,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindChannelByName)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_FindChannelByName", params, "s");
 
-	std::string const channel_name = amx_GetCppString(amx, params[1]);
+	std::string const channel_name = GetPawnStr(amx, params[1]);
 	Channel_t const &channel = ChannelManager::Get()->FindChannelByName(channel_name);
 
 	cell ret_val = channel ? channel->GetPawnId() : 0;
@@ -52,7 +83,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindChannelById)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_FindChannelById", params, "s");
 
-	Snowflake_t const channel_id = amx_GetCppString(amx, params[1]);
+	Snowflake_t const channel_id = GetPawnStr(amx, params[1]);
 	Channel_t const &channel = ChannelManager::Get()->FindChannelById(channel_id);
 
 	cell ret_val = channel ? channel->GetPawnId() : 0;
@@ -74,7 +105,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetChannelId)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], channel->GetId(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(channel->GetId()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -145,7 +176,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetChannelName)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], channel->GetName(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(channel->GetName()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -164,7 +195,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetChannelTopic)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], channel->GetTopic(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(channel->GetTopic()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -269,8 +300,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SendChannelMessage)
 		return 0;
 	}
 
-	auto message = amx_GetCppString(amx, params[2]);
-	if (message.length() > 2000)
+	auto message = GetPawnStr(amx, params[2]);
+	if (Utf8CharCount(message) > 2000)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"message must be shorter than 2000 characters");
@@ -278,8 +309,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SendChannelMessage)
 	}
 
 	auto
-		cb_name = amx_GetCppString(amx, params[3]),
-		cb_format = amx_GetCppString(amx, params[4]);
+		cb_name = GetPawnStr(amx, params[3]),
+		cb_format = GetPawnStr(amx, params[4]);
 
 	pawn_cb::Error cb_error;
 	auto cb = pawn_cb::Callback::Prepare(
@@ -310,8 +341,9 @@ AMX_DECLARE_NATIVE(Native::DCC_SetChannelName)
 		return 0;
 	}
 
-	auto name = amx_GetCppString(amx, params[2]);
-	if (name.length() < 2 || name.length() > 100)
+	auto name = GetPawnStr(amx, params[2]);
+	auto name_len = Utf8CharCount(name);
+	if (name_len < 2 || name_len > 100)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"name must be between 2 and 100 characters in length");
@@ -344,8 +376,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SetChannelTopic)
 		return 0;
 	}
 
-	auto topic = amx_GetCppString(amx, params[2]);
-	if (topic.length() > 1024)
+	auto topic = GetPawnStr(amx, params[2]);
+	if (Utf8CharCount(topic) > 1024)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"topic must be between 0 and 1024 characters in length");
@@ -463,7 +495,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetMessageId)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], msg->GetId(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(msg->GetId()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -535,7 +567,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetMessageContent)
 	}
 
 	cell ret_val = amx_SetCppString(
-		amx, params[2], msg->GetContent(), params[3]) == AMX_ERR_NONE;
+		amx, params[2], utils::ToPawnEncoding(msg->GetContent()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -752,8 +784,8 @@ AMX_DECLARE_NATIVE(Native::DCC_FindUserByName)
 	ScopedDebugInfo dbg_info(amx, "DCC_FindUserByName", params, "ss");
 
 	std::string const
-		user_name = amx_GetCppString(amx, params[1]),
-		discriminator = amx_GetCppString(amx, params[2]);
+		user_name = GetPawnStr(amx, params[1]),
+		discriminator = GetPawnStr(amx, params[2]);
 	User_t const &user = UserManager::Get()->FindUserByName(user_name, discriminator);
 
 	cell ret_val = user ? user->GetPawnId() : 0;
@@ -767,7 +799,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindUserById)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_FindUserById", params, "s");
 
-	Snowflake_t const user_id = amx_GetCppString(amx, params[1]);
+	Snowflake_t const user_id = GetPawnStr(amx, params[1]);
 	User_t const &user = UserManager::Get()->FindUserById(user_id);
 
 	cell ret_val = user ? user->GetPawnId() : 0;
@@ -789,7 +821,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetUserId)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], user->GetId(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(user->GetId()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -808,7 +840,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetUserName)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], user->GetUsername(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(user->GetUsername()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -827,7 +859,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetUserDiscriminator)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], user->GetDiscriminator(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(user->GetDiscriminator()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -891,7 +923,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindRoleByName)
 	ScopedDebugInfo dbg_info(amx, "DCC_FindRoleByName", params, "ds");
 
 	GuildId_t guildid = params[1];
-	std::string const role_name = amx_GetCppString(amx, params[2]);
+	std::string const role_name = GetPawnStr(amx, params[2]);
 
 	Guild_t const &guild = GuildManager::Get()->FindGuild(guildid);
 	if (!guild)
@@ -923,7 +955,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindRoleById)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_FindRoleById", params, "s");
 
-	Snowflake_t const role_id = amx_GetCppString(amx, params[1]);
+	Snowflake_t const role_id = GetPawnStr(amx, params[1]);
 	Role_t const &role = RoleManager::Get()->FindRoleById(role_id);
 
 	cell ret_val = role ? role->GetPawnId() : 0;
@@ -945,7 +977,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetRoleId)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], role->GetId(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(role->GetId()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -964,7 +996,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetRoleName)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], role->GetName(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(role->GetName()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -1114,7 +1146,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindGuildByName)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_FindGuildByName", params, "s");
 
-	std::string const guild_name = amx_GetCppString(amx, params[1]);
+	std::string const guild_name = GetPawnStr(amx, params[1]);
 	Guild_t const &guild = GuildManager::Get()->FindGuildByName(guild_name);
 
 	cell ret_val = guild ? guild->GetPawnId() : 0;
@@ -1128,7 +1160,7 @@ AMX_DECLARE_NATIVE(Native::DCC_FindGuildById)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_FindGuildById", params, "s");
 
-	Snowflake_t const guild_id = amx_GetCppString(amx, params[1]);
+	Snowflake_t const guild_id = GetPawnStr(amx, params[1]);
 	Guild_t const &guild = GuildManager::Get()->FindGuildById(guild_id);
 
 	cell ret_val = guild ? guild->GetPawnId() : 0;
@@ -1150,7 +1182,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetGuildId)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], guild->GetId(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(guild->GetId()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -1169,7 +1201,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetGuildName)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], guild->GetName(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(guild->GetName()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -1188,7 +1220,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetGuildOwnerId)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[2], guild->GetOwnerId(), params[3]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[2], utils::ToPawnEncoding(guild->GetOwnerId()), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -1386,7 +1418,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetGuildMemberNickname)
 		return 0;
 	}
 
-	cell ret_val = amx_SetCppString(amx, params[3], nick, params[4]) == AMX_ERR_NONE;
+	cell ret_val = amx_SetCppString(amx, params[3], utils::ToPawnEncoding(nick), params[4]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -1692,8 +1724,9 @@ AMX_DECLARE_NATIVE(Native::DCC_SetGuildName)
 		return 0;
 	}
 
-	auto name = amx_GetCppString(amx, params[2]);
-	if (name.length() < 2 || name.length() > 100)
+	auto name = GetPawnStr(amx, params[2]);
+	auto name_len = Utf8CharCount(name);
+	if (name_len < 2 || name_len > 100)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"name must be between 2 and 100 characters in length");
@@ -1720,8 +1753,9 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateGuildChannel)
 		return 0;
 	}
 
-	auto name = amx_GetCppString(amx, params[2]);
-	if (name.length() < 2 || name.length() > 100)
+	auto name = GetPawnStr(amx, params[2]);
+	auto name_len = Utf8CharCount(name);
+	if (name_len < 2 || name_len > 100)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"name must be between 2 and 100 characters in length");
@@ -1738,8 +1772,8 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateGuildChannel)
 	}
 
 	auto
-		cb_name = amx_GetCppString(amx, params[4]),
-		cb_format = amx_GetCppString(amx, params[5]);
+		cb_name = GetPawnStr(amx, params[4]),
+		cb_format = GetPawnStr(amx, params[5]);
 
 	pawn_cb::Error cb_error;
 	auto cb = pawn_cb::Callback::Prepare(
@@ -1784,7 +1818,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetGuildMemberNickname)
 		return 0;
 	}
 
-	guild->SetMemberNickname(user, amx_GetCppString(amx, params[3]));
+	guild->SetMemberNickname(user, GetPawnStr(amx, params[3]));
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -1942,7 +1976,7 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateGuildMemberBan)
 		return 0;
 	}
 
-	guild->CreateMemberBan(user, amx_GetCppString(amx, params[3]));
+	guild->CreateMemberBan(user, GetPawnStr(amx, params[3]));
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2023,7 +2057,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetGuildRoleName)
 		return 0;
 	}
 
-	guild->SetRoleName(role, amx_GetCppString(amx, params[3]));
+	guild->SetRoleName(role, GetPawnStr(amx, params[3]));
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2156,8 +2190,9 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateGuildRole)
 		return 0;
 	}
 
-	auto name = amx_GetCppString(amx, params[2]);
-	if (name.length() < 2 || name.length() > 100)
+	auto name = GetPawnStr(amx, params[2]);
+	auto name_len = Utf8CharCount(name);
+	if (name_len < 2 || name_len > 100)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"name must be between 2 and 100 characters in length");
@@ -2165,8 +2200,8 @@ AMX_DECLARE_NATIVE(Native::DCC_CreateGuildRole)
 	}
 
 	auto
-		cb_name = amx_GetCppString(amx, params[3]),
-		cb_format = amx_GetCppString(amx, params[4]);
+		cb_name = GetPawnStr(amx, params[3]),
+		cb_format = GetPawnStr(amx, params[4]);
 
 	pawn_cb::Error cb_error;
 	auto cb = pawn_cb::Callback::Prepare(
@@ -2254,11 +2289,12 @@ AMX_DECLARE_NATIVE(Native::DCC_SetBotNickname)
 		return 0;
 	}
 
-	auto nickname = amx_GetCppString(amx, params[2]);
+	auto nickname = GetPawnStr(amx, params[2]);
 	if (!nickname.empty()) // if nickname is empty it gets resetted/removed
 	{
 		// see https://discordapp.com/developers/docs/resources/user#usernames-and-nicknames
-		if (nickname.length() < 2 || nickname.length() > 32
+		auto nickname_len = Utf8CharCount(nickname);
+		if (nickname_len < 2 || nickname_len > 32
 			|| nickname == "discordtag" || nickname == "everyone" || nickname == "here"
 			|| nickname.front() == '@' || nickname.front() == '#' || nickname.front() == ':'
 			|| nickname.find("```") == 0)
@@ -2287,8 +2323,8 @@ AMX_DECLARE_NATIVE(Native::DCC_CreatePrivateChannel)
 	}
 
 	auto
-		cb_name = amx_GetCppString(amx, params[2]),
-		cb_format = amx_GetCppString(amx, params[3]);
+		cb_name = GetPawnStr(amx, params[2]),
+		cb_format = GetPawnStr(amx, params[3]);
 
 	pawn_cb::Error cb_error;
 	auto cb = pawn_cb::Callback::Prepare(
@@ -2329,7 +2365,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetBotActivity)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_SetBotActivity", params, "s");
 
-	ThisBot::Get()->SetActivity(amx_GetCppString(amx, params[1]));
+	ThisBot::Get()->SetActivity(GetPawnStr(amx, params[1]));
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2340,7 +2376,7 @@ AMX_DECLARE_NATIVE(Native::DCC_EscapeMarkdown)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_EscapeMarkdown", params, "drs");
 
-	auto const src = amx_GetCppString(amx, params[1]);
+	auto const src = GetPawnStr(amx, params[1]);
 	std::string dest;
 	dest.reserve(src.length());
 
@@ -2368,13 +2404,14 @@ AMX_DECLARE_NATIVE(Native::DCC_EscapeMarkdown)
 		dest.push_back(ch);
 	}
 
-	if (amx_SetCppString(amx, params[2], dest, params[3]) != AMX_ERR_NONE)
+	auto pawn_dest = utils::ToPawnEncoding(dest);
+	if (amx_SetCppString(amx, params[2], pawn_dest, params[3]) != AMX_ERR_NONE)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR, "couldn't set destination string");
 		return -1;
 	}
 
-	auto ret_val = static_cast<cell>(dest.length());
+	auto ret_val = static_cast<cell>(pawn_dest.length());
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
 }
@@ -2384,15 +2421,15 @@ AMX_DECLARE_NATIVE(Native::DCC_EscapeMarkdown)
 AMX_DECLARE_NATIVE(Native::DCC_CreateEmbed)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_CreateEmbed", params, "ssssdssss");
-	auto const title = amx_GetCppString(amx, params[1]);
-	auto const description = amx_GetCppString(amx, params[2]);
-	auto const url = amx_GetCppString(amx, params[3]);
-	auto const timestamp = amx_GetCppString(amx, params[4]);
+	auto const title = GetPawnStr(amx, params[1]);
+	auto const description = GetPawnStr(amx, params[2]);
+	auto const url = GetPawnStr(amx, params[3]);
+	auto const timestamp = GetPawnStr(amx, params[4]);
 	auto const color = static_cast<int>(params[5]);
-	auto const footer_text = amx_GetCppString(amx, params[6]);
-	auto const footer_icon_url = amx_GetCppString(amx, params[7]);
-	auto const thumbnail_url = amx_GetCppString(amx, params[8]);
-	auto const image_url = amx_GetCppString(amx, params[9]);
+	auto const footer_text = GetPawnStr(amx, params[6]);
+	auto const footer_icon_url = GetPawnStr(amx, params[7]);
+	auto const thumbnail_url = GetPawnStr(amx, params[8]);
+	auto const image_url = GetPawnStr(amx, params[9]);
 
 	EmbedId_t id = EmbedManager::Get()->AddEmbed(title, description, url, timestamp, color, footer_text, footer_icon_url, thumbnail_url, image_url);
 	if (!id)
@@ -2442,8 +2479,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SendChannelEmbedMessage)
 		return 0;
 	}
 
-	auto message = amx_GetCppString(amx, params[3]);
-	if (message.length() > 2000)
+	auto message = GetPawnStr(amx, params[3]);
+	if (Utf8CharCount(message) > 2000)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"message must be shorter than 2000 characters");
@@ -2451,8 +2488,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SendChannelEmbedMessage)
 	}
 
 	auto
-		cb_name = amx_GetCppString(amx, params[4]),
-		cb_format = amx_GetCppString(amx, params[5]);
+		cb_name = GetPawnStr(amx, params[4]),
+		cb_format = GetPawnStr(amx, params[5]);
 
 	pawn_cb::Error cb_error;
 	auto cb = pawn_cb::Callback::Prepare(
@@ -2481,8 +2518,8 @@ AMX_DECLARE_NATIVE(Native::DCC_AddEmbedField)
 		return 0;
 	}
 
-	auto const name = amx_GetCppString(amx, params[2]);
-	auto const value = amx_GetCppString(amx, params[3]);
+	auto const name = GetPawnStr(amx, params[2]);
+	auto const value = GetPawnStr(amx, params[3]);
 	auto const inline_ = static_cast<bool>(params[4]);
 	embed->AddField(name, value, inline_);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
@@ -2501,7 +2538,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedTitle)
 		return 0;
 	}
 
-	auto const title = amx_GetCppString(amx, params[2]);
+	auto const title = GetPawnStr(amx, params[2]);
 	embed->SetTitle(title);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2519,7 +2556,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedDescription)
 		return 0;
 	}
 
-	auto const description = amx_GetCppString(amx, params[2]);
+	auto const description = GetPawnStr(amx, params[2]);
 	embed->SetDescription(description);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2537,7 +2574,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedUrl)
 		return 0;
 	}
 
-	auto const url = amx_GetCppString(amx, params[2]);
+	auto const url = GetPawnStr(amx, params[2]);
 	embed->SetUrl(url);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2555,7 +2592,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedTimestamp)
 		return 0;
 	}
 
-	auto const timestamp = amx_GetCppString(amx, params[2]);
+	auto const timestamp = GetPawnStr(amx, params[2]);
 	embed->SetTimestamp(timestamp);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2591,8 +2628,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedFooter)
 		return 0;
 	}
 
-	auto const text = amx_GetCppString(amx, params[2]);
-	auto const icon_url = amx_GetCppString(amx, params[3]);
+	auto const text = GetPawnStr(amx, params[2]);
+	auto const icon_url = GetPawnStr(amx, params[3]);
 	embed->SetFooterText(text);
 	embed->SetFooterIconUrl(icon_url);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
@@ -2611,7 +2648,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedThumbnail)
 		return 0;
 	}
 
-	auto const url = amx_GetCppString(amx, params[2]);
+	auto const url = GetPawnStr(amx, params[2]);
 	embed->SetThumbnailUrl(url);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2629,7 +2666,7 @@ AMX_DECLARE_NATIVE(Native::DCC_SetEmbedImage)
 		return 0;
 	}
 
-	auto const url = amx_GetCppString(amx, params[2]);
+	auto const url = GetPawnStr(amx, params[2]);
 	embed->SetImageUrl(url);
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '1'");
 	return 1;
@@ -2655,8 +2692,8 @@ AMX_DECLARE_NATIVE(Native::DCC_DeleteInternalMessage)
 AMX_DECLARE_NATIVE(Native::DCC_CreateEmoji)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_CreateEmoji", params, "ss");
-	const auto& name = amx_GetCppString(amx, params[1]);
-	const auto& snowflake = amx_GetCppString(amx, params[2]);
+	const auto& name = GetPawnStr(amx, params[1]);
+	const auto& snowflake = GetPawnStr(amx, params[2]);
 
 	EmojiId_t id = EmojiManager::Get()->AddEmoji(snowflake, name);
 	if (!id)
@@ -2699,13 +2736,14 @@ AMX_DECLARE_NATIVE(Native::DCC_GetEmojiName)
 	}
 
 	dest = emoji->GetName();
-	if (amx_SetCppString(amx, params[2], dest, params[3]) != AMX_ERR_NONE)
+	auto pawn_dest = utils::ToPawnEncoding(dest);
+	if (amx_SetCppString(amx, params[2], pawn_dest, params[3]) != AMX_ERR_NONE)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR, "couldn't set destination string");
 		return -1;
 	}
 
-	return dest.length();
+	return pawn_dest.length();
 }
 
 // native DCC_CreateReaction(DCC_Message:message, DCC_Emoji:reaction_emoji);
@@ -2764,8 +2802,8 @@ AMX_DECLARE_NATIVE(Native::DCC_EditMessage)
 		return 0;
 	}
 
-	const auto content = amx_GetCppString(amx, params[2]);
-	if (content.length() > 2000)
+	const auto content = GetPawnStr(amx, params[2]);
+	if (Utf8CharCount(content) > 2000)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"message must be shorter than 2000 characters");
@@ -2801,8 +2839,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SetMessagePersistent)
 AMX_DECLARE_NATIVE(Native::DCC_CacheChannelMessage)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_CacheChannelMessage", params, "ssss");
-	const auto& channel_snowflake = amx_GetCppString(amx, params[1]);
-	const auto& message_snowflake = amx_GetCppString(amx, params[2]);
+	const auto& channel_snowflake = GetPawnStr(amx, params[1]);
+	const auto& message_snowflake = GetPawnStr(amx, params[2]);
 
 	if (!channel_snowflake.length() || !message_snowflake.length())
 	{
@@ -2822,8 +2860,8 @@ AMX_DECLARE_NATIVE(Native::DCC_CacheChannelMessage)
 	}
 
 	auto
-		cb_name = amx_GetCppString(amx, params[3]),
-		cb_format = amx_GetCppString(amx, params[4]);
+		cb_name = GetPawnStr(amx, params[3]),
+		cb_format = GetPawnStr(amx, params[4]);
 
 	pawn_cb::Error cb_error;
 	auto cb = pawn_cb::Callback::Prepare(
@@ -2843,9 +2881,9 @@ AMX_DECLARE_NATIVE(Native::DCC_CacheChannelMessage)
 AMX_DECLARE_NATIVE(Native::DCC_CreateCommand)
 {
 	ScopedDebugInfo dbg_info(amx, "DCC_CreateCommand", params, "sssii");
-	const auto& name = amx_GetCppString(amx, params[1]);
-	const auto& description = amx_GetCppString(amx, params[2]);
-	const auto& callback = amx_GetCppString(amx, params[3]);
+	const auto& name = GetPawnStr(amx, params[1]);
+	const auto& description = GetPawnStr(amx, params[2]);
+	const auto& callback = GetPawnStr(amx, params[3]);
 	const auto& allow_everyone = static_cast<bool>(params[4]);
 	const auto& guild = static_cast<GuildId_t>(params[5]);
 	//const auto& permissions_size = static_cast<size_t>(params[6]);
@@ -3012,7 +3050,7 @@ AMX_DECLARE_NATIVE(Native::DCC_GetInteractionContent)
 	}
 
 	cell ret_val = amx_SetCppString(
-		amx, params[2], interaction->GetOptions().at(0)->m_Value, params[3]) == AMX_ERR_NONE;
+		amx, params[2], utils::ToPawnEncoding(interaction->GetOptions().at(0)->m_Value), params[3]) == AMX_ERR_NONE;
 
 	Logger::Get()->LogNative(samplog_LogLevel::DEBUG, "return value: '{}'", ret_val);
 	return ret_val;
@@ -3091,8 +3129,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SendInteractionEmbed)
 		return 0;
 	}
 
-	auto message = amx_GetCppString(amx, params[3]);
-	if (message.length() > 2000)
+	auto message = GetPawnStr(amx, params[3]);
+	if (Utf8CharCount(message) > 2000)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"message must be shorter than 2000 characters");
@@ -3118,8 +3156,8 @@ AMX_DECLARE_NATIVE(Native::DCC_SendInteractionMessage)
 		return 0;
 	}
 
-	auto message = amx_GetCppString(amx, params[2]);
-	if (message.length() > 2000)
+	auto message = GetPawnStr(amx, params[2]);
+	if (Utf8CharCount(message) > 2000)
 	{
 		Logger::Get()->LogNative(samplog_LogLevel::ERROR,
 			"message must be shorter than 2000 characters");
@@ -3154,8 +3192,8 @@ AMX_DECLARE_NATIVE(Native::DCC_DeleteCommand)
 // native DCC_Option:DCC_AddCommandOption(const name[], const description[], type, bool:required = true, DCC_Option:parent_option);
 AMX_DECLARE_NATIVE(Native::DCC_AddCommandOption)
 {
-	const auto& name = amx_GetCppString(amx, params[1]);
-	const auto& description = amx_GetCppString(amx, params[2]);
+	const auto& name = GetPawnStr(amx, params[1]);
+	const auto& description = GetPawnStr(amx, params[2]);
 	int type = static_cast<int>(params[3]);
 	bool required = static_cast<bool>(params[4]);
 	


### PR DESCRIPTION
- Add CP874<->UTF-8 conversion for Pawn strings (Thai), applied to all natives (in/out).

- Count UTF-8 characters for Discord limits (e.g. 2000 chars) instead of bytes.

- Make init non-blocking by default; add config for block/timeout.

- Prevent watchdog from tearing down a slow-but-successful init; treat READY as connected and keep caching.

- Document new config keys in README.